### PR TITLE
WIP: docs(zh_CN): zh_CN localization

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ extra_css:
 theme:
   name: material
   custom_dir: theme_overrides
+  language: en
   palette:
     - media: "(prefers-color-scheme)"
       primary: deep purple
@@ -74,16 +75,34 @@ plugins:
   - privacy
   - i18n:
       languages:
+        # The theme: language key is required for every locale even if it doesn't require an alias (like zh_CN -> zh).
+        # Having it on one locale but not the latter ones causes it to leak downwards,
+        # Which kills the build for later locales due to template mismatch.
+        # I have zero idea why and I am too afraid to ask.
         - locale: fr
           name: French
           build: true
+          theme:
+            language: fr
         - locale: cs
           name: Čeština
           build: true
+          theme:
+            language: cs
+        - locale: zh_CN
+          name: 中文（中国）
+          build: true
+          site_name: Bazzite 指南
+          theme:
+            language: zh
+          nav_translations:
+            Home: 主页
         - locale: zh_HK
           name: 中文（香港）
           build: true
           site_name: Bazzite 指南
+          theme:
+            language: zh_HK
           nav_translations:
             Home: 主頁
             FAQ: 常見問題
@@ -175,6 +194,8 @@ plugins:
           default: true
           name: English
           build: true
+          theme:
+            language: en
 
   - search
   - macros:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,9 +76,9 @@ plugins:
   - i18n:
       languages:
         # The theme: language key is required for every locale even if it doesn't require an alias (like zh_CN -> zh).
-        # Having it on one locale but not the latter ones causes it to leak downwards,
-        # Which kills the build for later locales due to template mismatch.
-        # I have zero idea why and I am too afraid to ask.
+        # Having it on one locale but not the latter ones causes it to leak downwards (?),
+        # which kills the build for later locales due to template mismatch.
+        # I have zero idea why and at this point I am too afraid to ask.
         - locale: fr
           name: French
           build: true

--- a/src/Advanced/Auto-Mounting_Secondary_Drives.zh_CN.md
+++ b/src/Advanced/Auto-Mounting_Secondary_Drives.zh_CN.md
@@ -1,0 +1,61 @@
+---
+title: 自动挂载外接硬盘
+---
+
+# 自动挂载外接硬盘
+
+!!! info "MicroSD 卡一般不需要任何手动操作即可自动挂载。"
+
+## 视频指南
+
+https://youtu.be/fN9lvkkrExI
+
+## 设置自动挂载的新分区
+
+1. 启动![GNOME|50x50, 50%](../img/GNOME_Disks_icon.png)**磁盘**程序；
+
+2. 按需删除已有的分区，然后再可用空间里创建一个新分区；
+
+   ![](../img/automount.1.png)
+
+3. 设置分区名称和文件系统（建议 BTRFS 或 Ext4）。
+
+!!! warning "Bazzite 只接受 BTRFS 和 Ext4 文件系统自动挂载时出现的问题报告。"
+
+![](../img/automount.2_btrfs.1.png){data-gallery="step-2"}
+![](../img/automount.2_btrfs.2.png){data-gallery="step-2"}
+![](../img/automount.3.png){data-gallery="step-2"}
+
+重新启动之后，新分区应该就会在`/run/media/system/[分区名]`目录下自动挂载。
+
+![](../img/automount.4.png){data-gallery="step-3"}
+
+## 手动挂载
+
+![在 GNOME Disks 中配置挂载选项|690x465, 75%](../img/GNOME_Edit_Mount_Options.png)
+
+![GNOME Disks 的挂载选项|549x500, 75%](../img/GNOME_Mount_Options_new.png)
+
+如果还是不行，可能需要在选项最后继续添加`,user,exec`。
+
+![](../img/GNOME_Mount_Options_new.2.png)
+
+## 故障排除
+
+### 修改设置后启动时直接 Emergency Mode 了？
+
+通常来讲这是挂载选项配置错误导致的。参考以下视频指南以进行恢复：
+
+https://www.youtube.com/watch?v=-2wca_0CpXY
+
+### BTRFS 或 ext4 仍无法自动挂载（启动时提示需要密码授权）
+
+1. 手动挂载目标分区；
+
+2. 启动**磁盘**程序并选择目标；
+
+3. 点击设置图标 > 编辑挂载选项；
+
+4. 确认“用户会话默认值”为**未勾选**，“系统启动时挂载”为勾选，然后选择“确定”；
+
+5. 对所有受影响的分区重复同样的操作。处理完成后，`sudo cat /etc/fstab`的输出中应该会有每个目标分区对应的条目。

--- a/src/Advanced/Reset_Forgotten_User_Password.zh_CN.md
+++ b/src/Advanced/Reset_Forgotten_User_Password.zh_CN.md
@@ -1,0 +1,73 @@
+# 重置用户密码
+
+!!! important
+
+    本文的方法只适用于你忘记了当前密码的情况。如果你知道当前密码，应该通过桌面环境的正常方式修改。
+
+!!! warning
+
+    此处的步骤涉及非常底层的系统更改，请务必小心。
+
+![Edit the command for the latest boot entry|690x351](../img/Edit_the_command_for_the_latest_boot_entry.png)
+
+1. 重启设备。
+2. 如果 GRUB 不默认显示，开机时按 <kbd>Esc</kbd> 键进入 GRUB 菜单。
+   a. 如果按 <kbd>Esc</kbd> 的次数太多，可能会进入 GRUB shell （`grub>`）；
+   b. 此时输入 `exit` 并按 <kbd>Enter</kbd> 以回到 GRUB 主菜单。
+3. 通过上下键选择最新版本的部署（通常为`ostree:0`），按 <kbd>E</kbd>以进入编辑模式。
+
+![Boot with init=/bin/bash|689x359](../img/Boot_with_init_bin_bash.jpeg)
+
+在自定义命令的界面中，找到 `linux` 开头的一行，在最后输入 `init=/bin/bash`。
+
+![Reboot|689x359](../img/Reset_Password_Reboot.jpeg)
+
+按 <kbd>Ctrl</kbd>+<kbd>X</kbd> 以按当前命令启动。
+
+进入命令行界面后：
+
+1. 挂载 SELinux 系统
+
+   `mount -t selinuxfs selinuxfs /sys/fs/selinux`
+
+2. 加载 SELinux 策略
+
+   `/sbin/load_policy`
+
+3. 更改密码 (记得替换用户名，比如`passwd bazzite`)
+
+   `passwd [INSERT USERNAME HERE]`
+
+4. 强制存储读写同步
+
+   `sync`
+
+5. 重新启动
+
+   `/sbin/reboot -ff`
+
+![Commands|690x334](../img/Reset_Password_Commands.png)
+
+之后即可使用新的密码登录。
+
+> 感谢 [Colin Walters](https://github.com/cgwalters) 在[这个 Issue](https://github.com/ublue-os/main/issues/469#issuecomment-1885264886) 下提供的方案。
+
+## 竟！然！不！许！
+
+SELinux 似乎是经常被忘记的一步。由于 SELinux 事关安全配置，这会导致重启之后任何程序都无法访问或读写保存实际密码的`/etc/shadow`文件。
+
+一种比较方便的检查方法是直接查询 `/etc/shadow` 的 SELinux 上下文。执行这条命令：
+
+`ls -Z /etc/shadow`
+
+![ls -Z /etc/shadow|690x334](../img/Unlabeled_Etc_Shadow.png)
+
+_unlabeled_t_ 说明当前的 SELinux 配置出错。确定 SELinux 策略正确加载后，用以下命令进行修复：
+
+`restorecon -v /etc/shadow`
+
+修复完成后，`ls -Z /etc/shadow`应该报告：
+
+`system_u:object_r:shadow_t:s0   /etc/shadow`
+
+之后再次重启即可恢复正常。

--- a/src/Advanced/Reset_Forgotten_User_Password.zh_CN.md
+++ b/src/Advanced/Reset_Forgotten_User_Password.zh_CN.md
@@ -8,7 +8,7 @@
 
     此处的步骤涉及非常底层的系统更改，请务必小心。
 
-![Edit the command for the latest boot entry|690x351](../img/Edit_the_command_for_the_latest_boot_entry.png)
+![为最新的启动菜单项修改命令|690x351,75%](../img/Edit_the_command_for_the_latest_boot_entry.png)
 
 1. 重启设备。
 2. 如果 GRUB 不默认显示，开机时按 <kbd>Esc</kbd> 键进入 GRUB 菜单。
@@ -16,11 +16,11 @@
    b. 此时输入 `exit` 并按 <kbd>Enter</kbd> 以回到 GRUB 主菜单。
 3. 通过上下键选择最新版本的部署（通常为`ostree:0`），按 <kbd>E</kbd>以进入编辑模式。
 
-![Boot with init=/bin/bash|689x359](../img/Boot_with_init_bin_bash.jpeg)
+![使用 init=/bin/bash 命令启动|689x359,75%](../img/Boot_with_init_bin_bash.jpeg)
 
 在自定义命令的界面中，找到 `linux` 开头的一行，在最后输入 `init=/bin/bash`。
 
-![Reboot|689x359](../img/Reset_Password_Reboot.jpeg)
+![重新启动|689x359,75%](../img/Reset_Password_Reboot.jpeg)
 
 按 <kbd>Ctrl</kbd>+<kbd>X</kbd> 以按当前命令启动。
 

--- a/src/Advanced/add-user-to-group.zh_CN.md
+++ b/src/Advanced/add-user-to-group.zh_CN.md
@@ -4,7 +4,7 @@ title: 将用户添加到组
 
 # 将用户添加到组
 
-## Foreword
+## 前言
 
 [Users and Groups](https://wiki.archlinux.org/title/Users_and_groups) are used on Linux for access control, that is, to control access to the system's files, directories, and peripherals, and is cruicial to how Linux works.
 
@@ -113,7 +113,8 @@ sudo usermod -aG <your_group_name> <username>
 
 ---
 
-## <del>diannaobaozhale</del>/配置出错后的修复 
+## 配置出错后的修复
+<small>_diannaobaozhale_</small>
 
 如果你意外删除了 `/etc/group` 或写入了错误的配置，可能会出现一种意外情况：你可以正常达到图形界面，但以下功能无法使用：
 

--- a/src/Advanced/add-user-to-group.zh_CN.md
+++ b/src/Advanced/add-user-to-group.zh_CN.md
@@ -1,0 +1,205 @@
+---
+title: 将用户添加到组
+---
+
+# 将用户添加到组
+
+## Foreword
+
+[Users and Groups](https://wiki.archlinux.org/title/Users_and_groups) are used on Linux for access control, that is, to control access to the system's files, directories, and peripherals, and is cruicial to how Linux works.
+
+!!! note "The following docs should also be applicable to other Fedora Atomic systems."
+
+---
+
+## Adding User to a Group on Atomic Systems
+
+[Bazzite is based on Fedora Atomic](/General/Fedora_Atomic_Comparison/#comparison-of-bazzite-upstream-fedora-atomic-desktop), and Atomic systems use a slightly different way of managing Users & Groups. Therefore, `usermod` cannot be used directly. The following details steps to add your user to a particular group.
+
+!!! warning "Follow this guide at your own discretion because you can **break** your system attempting any of this."
+
+!!! info "If you only need to add your user to the input group for controller compatibility purposes, use the automated script at **Bazzite Portal → Tweak System → Add input to your user groups**."
+
+---
+
+#### 1. Backup User Groups 
+
+Before starting, backup your user groups in `/etc/group` by running the following command:
+
+```bash
+sudo cp /etc/group /etc/group.bak
+```
+
+This copies your current group file to a file called `group.bak`. Additionally, it may prove to be helpful later on if you view and write down the current contents in `/etc/group`.
+
+---
+
+#### 2. Copy Group ID from `/usr/`
+
+The Group ID then needs to be identified and copied. It can be found for any known group by running the following command:
+
+!!! tip "Remember to replace `<your_group_name>` with the actual group name."
+
+```bash
+grep "<your_group_name>" /usr/lib/group
+```
+
+!!! example
+
+    For example, the entry for the `dialout` group is `dialout:x:18`:
+
+    ```bash
+    grep "dialout" /usr/lib/group
+    ```
+    returns
+    ```console
+    dialout:x:18
+    ```
+
+!!! info "`/lib/` is a symlink to `/usr/lib/`."
+
+---
+
+#### 3. Write Group ID to Group File
+
+This Group ID needs to be written into the working copy at `/etc/group`. This can be done by appending the entry manually to the `/etc/group` file, or via this one liner:
+
+!!! tip "Remember to replace `<your_group_name>` with the actual group name."
+
+```bash
+grep "<your_group_name>" /usr/lib/group | sudo tee -a /etc/group
+```
+
+!!! example
+    
+    ```bash
+    grep "dialout" /usr/lib/group | sudo tee -a /etc/group
+    ```
+
+!!! warning "Do **NOT** <small>_try to be smart and_</small> use bash's `>` or `>>` operator in this case. `>` overwrites the file, and both only work in a root shell. Follow the instructions."
+
+---
+
+#### 4. Use `usermod`
+
+We can then add the user to group with the following command:
+
+!!! tip "Remember to replace `<your_group_name>` with the actual group name, and `<username>` with your username."
+
+```bash
+sudo usermod -aG <your_group_name> <username>
+```
+!!! example
+    
+    ```bash
+    sudo usermod -aG dialout bazzite
+    ```
+
+---
+
+#### 5. 检查无误后重启
+
+修改完成后，务必再次查看`/etc/group`文件，确定以下三条条目都在：
+
+!!! tip "`<your_group_name>`应对应实际的组名，`<username>`对应你的用户名，`<group_ID>`对应组ID。"
+
+*   `wheel:x:10:<username>`
+*   `<username>:x:1000`
+*   `<your_group_name>:x:<group_ID>:<username>`
+
+如果你的`/etc/group`文件缺少任意一条，**不要重新启动或关机**，立刻前往 [Bazzite 的官方 Discord](/community/#discord-no-discord-account)上求助。
+
+如果一切正常，重新启动后修改就能生效。
+
+---
+
+## <del>diannaobaozhale</del>/配置出错后的修复 
+
+如果你意外删除了 `/etc/group` 或写入了错误的配置，可能会出现一种意外情况：你可以正常达到图形界面，但以下功能无法使用：
+
+*   重启后的用户登录
+*   Polkit 审核
+*   `sudo`
+
+此时你将无法直接修复 `/etc/group`，因为这需要 Polkit 或者 `sudo` 提供批准。
+
+To fix this, the file needs to be edited in a root shell before the system arrives at a graphical session.
+
+---
+
+#### 1. Reboot into GRUB Command Editor
+
+Reboot your device and tap <kbd>Esc</kbd> on the keyboard to reach the GRUB boot menu. If you have not hidden your GRUB menu, you may also tap <kbd>↓</kbd> continuously until the GRUB menu appears.
+
+!!! tip
+
+    *   If you press <kbd>Esc</kbd> too many times, you may end up at a `grub>` prompt.
+    *   Return to the boot menu by typing `exit` and pressing <kbd>Enter</kbd>.
+
+![Edit the command for the latest boot entry|690x351,75%](../img/Edit_the_command_for_the_latest_boot_entry.png)
+
+---
+
+#### 2. Edit the Boot Command Temporarily
+
+Edit the last deployment by pressing <kbd>E</kbd> on your keyboard.
+
+![Boot with init=/bin/bash|689x359,75%](../img/Boot_with_init_bin_bash.jpeg)
+
+Append `init=/bin/bash` to the line beginning with `linux`.
+
+![Reboot|689x359,75%](../img/Reset_Password_Reboot.jpeg)
+
+Continue the boot process with <kbd>Ctrl</kbd>+<kbd>X</kbd>.
+
+---
+
+#### 3. Fix `/etc/group`
+
+Once the boot process completes, the system will drop you to a **root shell**.
+
+View and edit your `/etc/group` with any CLI text editor, such as `vim` or `nano`. It should contain the following:
+
+!!! tip "Replace `<username>` with your username. If you hadn't set it during installation, it would be set to a default of `bazzite`."
+
+*   `wheel:x:10:<username>`
+*   `<username>:x:1000`
+
+!!! example 
+    
+    ```console
+    bash-5.2# cat /etc/group
+    wheel:x:10:bazzite
+    bazzite:x:1000
+    ```
+!!! note "If you have previously backed up your `/etc/group` file, you can copy it back with `cp /etc/group.bak /etc/group`"
+
+---
+
+#### 4. Add User to `wheel` Group
+
+After fixing `/etc/group`, SELinux needs to be temporarily loaded to add the user back to the group properly. Run the following commands:
+
+Mount SELinux
+```bash
+mount -t selinuxfs selinuxfs /sys/fs/selinux
+```
+Load SELinux Policy
+```bash
+/sbin/load_policy
+```
+Add user to `wheel` Group
+!!! tip "Replace `<username>` with your username. If you hadn't set it during installation, it would be set to a default of `bazzite`."
+```bash
+/sbin/usermod -aG wheel <username>
+```
+Sync configurations
+```bash
+sync
+```
+Reboot
+```bash
+/sbin/reboot -ff
+```
+
+---

--- a/src/Advanced/add-user-to-group.zh_CN.md
+++ b/src/Advanced/add-user-to-group.zh_CN.md
@@ -22,7 +22,7 @@ title: 将用户添加到组
 
 ---
 
-#### 1. Backup User Groups 
+#### 1. 备份当前用户组配置 
 
 Before starting, backup your user groups in `/etc/group` by running the following command:
 

--- a/src/Advanced/add-user-to-group.zh_CN.md
+++ b/src/Advanced/add-user-to-group.zh_CN.md
@@ -24,7 +24,7 @@ title: 将用户添加到组
 
 #### 1. 备份当前用户组配置 
 
-Before starting, backup your user groups in `/etc/group` by running the following command:
+在继续之前，用以下命令创建你当前的用户组配置的备份：
 
 ```bash
 sudo cp /etc/group /etc/group.bak

--- a/src/Advanced/add-user-to-group.zh_CN.md
+++ b/src/Advanced/add-user-to-group.zh_CN.md
@@ -6,19 +6,19 @@ title: 将用户添加到组
 
 ## 前言
 
-[Users and Groups](https://wiki.archlinux.org/title/Users_and_groups) are used on Linux for access control, that is, to control access to the system's files, directories, and peripherals, and is cruicial to how Linux works.
+[用户和组](https://wiki.archlinuxcn.org/wiki/Users_and_groups) 是 Linux 上控制访问权限的两个层级。其配置关系到整个系统文件和设备等各方面的操作，因此十分重要。
 
-!!! note "The following docs should also be applicable to other Fedora Atomic systems."
+!!! note "以下指南对其他基于 Fedora Atomic 的系统也基本适用。"
 
 ---
 
-## Adding User to a Group on Atomic Systems
+## 在 Atomic 系统下将用户添加到组
 
-[Bazzite is based on Fedora Atomic](/General/Fedora_Atomic_Comparison/#comparison-of-bazzite-upstream-fedora-atomic-desktop), and Atomic systems use a slightly different way of managing Users & Groups. Therefore, `usermod` cannot be used directly. The following details steps to add your user to a particular group.
+[Bazzite 基于 Fedora Atomic](/General/Fedora_Atomic_Comparison/#comparison-of-bazzite-upstream-fedora-atomic-desktop)，因此用户和组的配置方式与传统发行版略有不同，这导致单纯使用`usermod`通常不足以完成必要的配置。以下将给出完整的将用户添加到任意组的指南。
 
-!!! warning "Follow this guide at your own discretion because you can **break** your system attempting any of this."
+!!! warning "以下指南涉及对系统底层配置的修改，请务必小心。"
 
-!!! info "If you only need to add your user to the input group for controller compatibility purposes, use the automated script at **Bazzite Portal → Tweak System → Add input to your user groups**."
+!!! info "如果你只是需要将用户添加到`input`组来解决一些游戏控制器兼容性相关的问题，建议使用**Bazzite Portal → Tweak System → Add input to your user groups**这一快捷命令。"
 
 ---
 
@@ -30,15 +30,15 @@ title: 将用户添加到组
 sudo cp /etc/group /etc/group.bak
 ```
 
-This copies your current group file to a file called `group.bak`. Additionally, it may prove to be helpful later on if you view and write down the current contents in `/etc/group`.
+这会把你当前的`/etc/group`文件复制到`group.bak`。除此之外，也建议你查看并手动记录当前`/etc/group`的内容，这样出现问题时会更方便修复。
 
 ---
 
-#### 2. Copy Group ID from `/usr/`
+#### 2. 从`/usr/`复制预先定义的组 ID
 
-The Group ID then needs to be identified and copied. It can be found for any known group by running the following command:
+接下来，应确定要修改的组的 ID 以准备复制。对于预定义的组，以下命令可以提取出已经配置好的组 ID：
 
-!!! tip "Remember to replace `<your_group_name>` with the actual group name."
+!!! tip "`<your_group_name>`必须替换成你实际需要的组的名称。"
 
 ```bash
 grep "<your_group_name>" /usr/lib/group
@@ -46,25 +46,25 @@ grep "<your_group_name>" /usr/lib/group
 
 !!! example
 
-    For example, the entry for the `dialout` group is `dialout:x:18`:
+    对于`dialout`组，得到的结果应该是`dialout:x:18`：
 
     ```bash
     grep "dialout" /usr/lib/group
     ```
-    returns
+    预期输出：
     ```console
     dialout:x:18
     ```
 
-!!! info "`/lib/` is a symlink to `/usr/lib/`."
+!!! info "`/lib/`是指向`/usr/lib/`的符号链接。"
 
 ---
 
-#### 3. Write Group ID to Group File
+#### 3. 将所需的组 ID 写入到`/etc/group`
 
-This Group ID needs to be written into the working copy at `/etc/group`. This can be done by appending the entry manually to the `/etc/group` file, or via this one liner:
+接下来需要将找到的组的条目写入到`/etc/group`。你可以手动添加，也可以通过以下命令快速导入：
 
-!!! tip "Remember to replace `<your_group_name>` with the actual group name."
+!!! tip "`<your_group_name>`必须替换成你实际需要的组的名称。"
 
 ```bash
 grep "<your_group_name>" /usr/lib/group | sudo tee -a /etc/group
@@ -76,15 +76,15 @@ grep "<your_group_name>" /usr/lib/group | sudo tee -a /etc/group
     grep "dialout" /usr/lib/group | sudo tee -a /etc/group
     ```
 
-!!! warning "Do **NOT** <small>_try to be smart and_</small> use bash's `>` or `>>` operator in this case. `>` overwrites the file, and both only work in a root shell. Follow the instructions."
+!!! warning "Bash 的`>`或`>>`操作符在此处**无法生效**，且`>`会完全覆盖文件的原有内容。建议严格按照此处给出的命令输入。"
 
 ---
 
-#### 4. Use `usermod`
+#### 4. 使用`usermod`命令
 
-We can then add the user to group with the following command:
+接下来，用以下命令将用户添加到组：
 
-!!! tip "Remember to replace `<your_group_name>` with the actual group name, and `<username>` with your username."
+!!! tip "`<your_group_name>`应对应实际的组名，`<username>`对应你的用户名。"
 
 ```bash
 sudo usermod -aG <your_group_name> <username>
@@ -99,7 +99,7 @@ sudo usermod -aG <your_group_name> <username>
 
 #### 5. 检查无误后重启
 
-修改完成后，务必再次查看`/etc/group`文件，确定以下三条条目都在：
+修改完成后，务必再次查看`/etc/group`文件，确定以下三条都在：
 
 !!! tip "`<your_group_name>`应对应实际的组名，`<username>`对应你的用户名，`<group_ID>`对应组ID。"
 
@@ -116,7 +116,7 @@ sudo usermod -aG <your_group_name> <username>
 ## 配置出错后的修复
 <small>_diannaobaozhale_</small>
 
-如果你意外删除了 `/etc/group` 或写入了错误的配置，可能会出现一种意外情况：你可以正常达到图形界面，但以下功能无法使用：
+如果你意外删除了 `/etc/group` 或写入了错误的配置，可能会出现一种意外情况：你可以正常使用图形界面，但以下功能无法使用：
 
 *   重启后的用户登录
 *   Polkit 审核
@@ -124,44 +124,44 @@ sudo usermod -aG <your_group_name> <username>
 
 此时你将无法直接修复 `/etc/group`，因为这需要 Polkit 或者 `sudo` 提供批准。
 
-To fix this, the file needs to be edited in a root shell before the system arrives at a graphical session.
+为了修复该问题，需要在进入图形界面之前先行启动一个 Root Shell。
 
 ---
 
-#### 1. Reboot into GRUB Command Editor
+#### 1. 重新启动到 GRUB 菜单
 
-Reboot your device and tap <kbd>Esc</kbd> on the keyboard to reach the GRUB boot menu. If you have not hidden your GRUB menu, you may also tap <kbd>↓</kbd> continuously until the GRUB menu appears.
+重新启动设备，并在开机过程中按<kbd>Esc</kbd>键以进入 GRUB 菜单。对于双系统或没有隐藏 GRUB 菜单的配置，也可以在菜单出现时按<kbd>↓</kbd>以打断自动的倒计时。
 
 !!! tip
 
-    *   If you press <kbd>Esc</kbd> too many times, you may end up at a `grub>` prompt.
-    *   Return to the boot menu by typing `exit` and pressing <kbd>Enter</kbd>.
+    *   如果按<kbd>Esc</kbd>的次数太多，你可能会看到一个`grub>`的 Shell 界面；
+    *   此时应输入`exit`并按<kbd>Enter</kbd>，以回到 GRUB 的主要菜单。
 
-![Edit the command for the latest boot entry|690x351,75%](../img/Edit_the_command_for_the_latest_boot_entry.png)
-
----
-
-#### 2. Edit the Boot Command Temporarily
-
-Edit the last deployment by pressing <kbd>E</kbd> on your keyboard.
-
-![Boot with init=/bin/bash|689x359,75%](../img/Boot_with_init_bin_bash.jpeg)
-
-Append `init=/bin/bash` to the line beginning with `linux`.
-
-![Reboot|689x359,75%](../img/Reset_Password_Reboot.jpeg)
-
-Continue the boot process with <kbd>Ctrl</kbd>+<kbd>X</kbd>.
+![为最新的启动菜单项修改命令|690x351,75%](../img/Edit_the_command_for_the_latest_boot_entry.png)
 
 ---
 
-#### 3. Fix `/etc/group`
+#### 2. 临时修改启动命令
 
-Once the boot process completes, the system will drop you to a **root shell**.
+选择最新的部署，按<kbd>E</kbd>以进行临时的启动命令修改。
 
-View and edit your `/etc/group` with any CLI text editor, such as `vim` or `nano`. It should contain the following:
+![使用 init=/bin/bash 命令启动|689x359,75%](../img/Boot_with_init_bin_bash.jpeg)
 
-!!! tip "Replace `<username>` with your username. If you hadn't set it during installation, it would be set to a default of `bazzite`."
+在`linux`开头的一行的末尾，输入`init=/bin/bash`。
+
+![重新启动|689x359,75%](../img/Reset_Password_Reboot.jpeg)
+
+按<kbd>Ctrl</kbd>+<kbd>X</kbd>以使用新命令启动。
+
+---
+
+#### 3. 修复`/etc/group`
+
+如果启动配置修改正确，你应该会进入一个 **root** 权限的 Shell，绕过`sudo`等限制。
+
+用你习惯的命令行文本编辑器，比如`vim`或`nano`来修改`/etc/group`，确保其至少包含以下内容：
+
+!!! tip "`<username>`必须对应修改为你实际使用的用户名。如果你在安装 Bazzite 时没有手动配置，则应使用默认的`bazzite`。"
 
 *   `wheel:x:10:<username>`
 *   `<username>:x:1000`
@@ -173,32 +173,32 @@ View and edit your `/etc/group` with any CLI text editor, such as `vim` or `nano
     wheel:x:10:bazzite
     bazzite:x:1000
     ```
-!!! note "If you have previously backed up your `/etc/group` file, you can copy it back with `cp /etc/group.bak /etc/group`"
+!!! note "如果你有出现问题之前的`/etc/group`备份，则可以使用`cp /etc/group.bak /etc/group`命令以进行还原。"
 
 ---
 
-#### 4. Add User to `wheel` Group
+#### 4. 将用户添加到`wheel`组
 
-After fixing `/etc/group`, SELinux needs to be temporarily loaded to add the user back to the group properly. Run the following commands:
+修改好`/etc/group`之后，为了将你的用户正确加入`wheel`组，必须暂时加载系统的 SELinux 策略。
 
-Mount SELinux
+挂载 SELinux
 ```bash
 mount -t selinuxfs selinuxfs /sys/fs/selinux
 ```
-Load SELinux Policy
+加载 SELinux 策略
 ```bash
 /sbin/load_policy
 ```
-Add user to `wheel` Group
-!!! tip "Replace `<username>` with your username. If you hadn't set it during installation, it would be set to a default of `bazzite`."
+将用户添加到`wheel`组
+!!! tip "`<username>`必须对应修改为你实际使用的用户名。如果你在安装 Bazzite 时没有手动配置，则应使用默认的`bazzite`。"
 ```bash
 /sbin/usermod -aG wheel <username>
 ```
-Sync configurations
+同步 I/O
 ```bash
 sync
 ```
-Reboot
+重新启动
 ```bash
 /sbin/reboot -ff
 ```

--- a/src/Advanced/cardwire.zh_CN.md
+++ b/src/Advanced/cardwire.zh_CN.md
@@ -1,0 +1,66 @@
+---
+title: Cardwire
+---
+
+# Cardwire
+
+![Cardwire 界面截图|2224x1468, 25%](https://github.com/OpenGamingCollective/cardwire/raw/main/assets/org.opengamingcollective.cardwire.screenshot.png)
+
+## 概述
+
+Cardwire 通过 eBPF 和 LSM 触发器监听并按规则处理对显卡设备节点的调用请求，包括`/dev/dri/renderDX`、`/dev/dri/cardX`、sysfs 的 `config`、`nvidiaX`等各类显卡相关文件。
+
+显卡被“阻挡”时，eBPF 会拦截所有对该设备的请求并返回 -ENOENT 错误代码，因此从调用程序的视角来看这块显卡并不存在。和常规的显卡控制方式相比这提供了一些独特优势：
+
+-   程序启动更快：有些程序（尤其是 Electron 或 GTK 程序）总会尝试遍历所有显卡，这往往会导致程序浪费 3-4 秒的时间重新启动休眠状态的显卡；
+-   省电：在系统调用层面拦截所有请求使得显卡可以始终停留在最低级的电源状态（D3cold）而不需要被唤醒，这在笔记本类的设备上有助于延长电池续航；
+-   非侵入性：传统方法往往需要进行暂时禁用相关驱动或其他影响整个系统的操作，而 Cardwire 的配置方式的适用范围可以精细控制，开关也更方便。
+
+!!! note "Cardwire 只支持 Wayland 桌面环境，不支持 X11。"
+
+---
+
+## 配置
+
+Cardwire 可以通过自带的图形界面或命令行进行设置。
+
+```console
+CLI for cardwire GPU management
+
+Usage: cardwire <COMMAND>
+
+Commands:
+set      Set to the desired mode
+get      Get the current mode
+list     Print the gpu list
+gpu      Manage a specific GPU by its id
+config   Manage daemon configuration
+manager  Manager operations
+debug    Debug operations
+launch   Launch a program on the specified GPU
+help     Print this message or the help of the given subcommand(s)
+
+Options:
+-h, --help     Print help
+-V, --version  Print version
+```
+
+---
+
+## 用法
+
+如果需要一个 Steam 游戏总是在一块特定显卡上运行，则应设置以下 [Steam 启动选项](/Gaming/launch-options-env-variables.md)：
+
+```bash
+cardwire launch %command%
+```
+
+!!! note "Cardwire 不需要也不应该和`switcherooctl`、`envycontrol`或`supergfxctl`等其他显卡管理工具一起使用。"
+
+> 参考 [Cardwire 官方文档](https://opengamingcollective.github.io/cardwire/)以获取更多信息。
+
+---
+
+## 项目官网
+
+https://github.com/OpenGamingCollective/cardwire

--- a/src/Advanced/dracut-and-initramfs.zh_CN.md
+++ b/src/Advanced/dracut-and-initramfs.zh_CN.md
@@ -1,0 +1,26 @@
+---
+title: 在 Bazzite 中配置 modprobe
+---
+
+# 在 Bazzite 中配置 modprobe
+
+## 如果你只是需要为一个模块提供选项，建议使用 `rpm-ostree kargs`
+修改 initramfs 和 modprobe 配置会明显拉长所有更新需要的时间，通常可达数分钟。绝大多数情况下，modprobe 相关的修改可以通过内核参数来实现。
+
+作为示范，接下来将以下的 modprobe 选项转换为内核参数：
+```
+options hid_apple fnmode=2
+```
+对应的内核参数：
+```
+hid_apple.fnmode=2
+```
+使用以下命令使其在每次启动时生效：
+```
+rpm-ostree kargs --append-if-missing="hid_apple.fnmode=2"
+```
+因为内核参数不像 initramfs 需要随系统更新重新生成，所以该方法不会影响更新时间。
+
+## 关于内核参数的上游文档
+
+有关该问题的更多信息，请参考[**上游 Fedora CoreOS 的文档**](https://docs.fedoraproject.org/en-US/fedora-coreos/kernel-args/)。

--- a/src/Advanced/scopebuddy.md
+++ b/src/Advanced/scopebuddy.md
@@ -159,6 +159,21 @@ This let's us re-use the `SCB_GAMESCOPE_ARGS` we set in our `scb.conf`
 
 Yes! There is one on flathub: [ScopeBuddy GUI](https://flathub.org/en/apps/io.github.rfrench3.scopebuddy-gui)
 
+### Is there an easy way to get the directory path to the game
+
+Yes, scopebuddy has a built in function for this which requires awk.
+Add this into your your AppID config.
+
+```bash
+GAMEDIR=$(SCB_GetGameDir "$command")
+```
+
+This will make `$GAMEDIR` contain the path to the directory containing the games binary/exe.
+
+!!! note
+
+    This function is designed for use with Steam, it might work in Lutris and Heroic, but has not been tested against it.
+
 ### Can I use ScopeBuddys functions without using gamescope?
 
 Yes, just use the env var `SCB_NOSCOPE=1` in the Launch Options like this
@@ -229,6 +244,7 @@ Some handy variables available to you are
 - `$SCB_GAMEMODE` will be set to 1 if ScopeBuddy is ran from within steam Steam Gaming Mode (this also implies `SCB_NOSCOPE=1`)
 - `$SCB_CONFIGDIR` will be `$HOME/.config/scopebuddy` this means you can source other configs within your config (please do not make an infinite loop!)
 - `$command` will contain the expanded %command% variable from Steam and any launch options you added after it.
+- `GAMEDIR=$(SCB_GetGameDir "$command")` will add the games directory (that contains the binary/exe) into `$GAMEDIR` for use in your scripts.
 
 Let your creativity go wild!
 But please be responsible!
@@ -248,18 +264,7 @@ SCB_NOSCOPE=1
 command+=" -provider Portal"
 
 # Get the game directory from the expanded %command% variable from steam
-cmdARGS=$(echo $command | awk -F '" "' '{ print NF }')
-for ((i = 1; i <= cmdARGS; i++))
-do
-    GAMEDIR=$(echo $command | awk -F '" "' -v i="$i" '{ print $i }')
-    # If we found "waitforexitandrun"
-    if [ "$GAMEDIR" == "waitforexitandrun" ]; then
-        # Increase i by 1 and grab the game directory then exit the loop early
-        i=$(($i+1))
-        GAMEDIR=$(echo $command | awk -F '" "' -v i="$i" '{ print $i }' | sed 's/\/Gw2-64.exe//')
-        break
-    fi
-done
+GAMEDIR=$(SCB_GetGameDir "$command")
 
 # Run the arcdps updater script before game starts
 "$SCB_CONFIGDIR/scripts/dl-arcdps" "$GAMEDIR"

--- a/src/Advanced/sunshine.zh_CN.md
+++ b/src/Advanced/sunshine.zh_CN.md
@@ -1,0 +1,213 @@
+---
+title: 在 Bazzite 上配置 Sunshine
+---
+
+# 在 Bazzite 上配置 Sunshine
+
+## Sunshine 和 Bazzite 的爱恨情仇说是
+
+Sunshine 以前是集成进 Bazzite 镜像中的，但由于其很长一段时间没有提供 Fedora 43 和 44 的稳定包，导致 Bazzite 必须改用测试版的 Sunshine。又因为 Sunshine 测试版多次反复修改内部启动项文件的名称，导致 Bazzite 更新后 Sunshine 无法工作的情况多次出现。
+将 Sunshine 从镜像中移除并单独管理使得它能够单独锁定到特定版本，这样便绕过了先前提到的问题。
+
+目前推荐的配置 Sunshine 的方法是通过 **Bazzite Portal**，对应的是官方支持的 Flatpak 安装及相关配置。
+
+!!! info "Sunshine 于 2026/05/16 终于发布了 F43 和 F44 的官方包，但 2026/04/29 的 Fedora 44 的更新中 Bazzite 已经从镜像中移除了 Sunshine 并转移至单独配置。"
+
+## 我正在使用 Sunshine，需要做什么？
+
+!!! notice "掌机版的用户请参考[这一部分](/Advanced/sunshine.md#setting-up-sunshine-on-deck-images)。"
+
+以下指南通过 Bazzite Portal 的快捷命令帮助转换到 Flatpak 安装的 Sunshine。
+!!! warning "强烈建议你确认能够物理访问目标设备，或配置好 SSH 连接。如果你只通过 Sunshine 连接，配置过程中连接可能会中断。"
+
+1. 启动 Bazzite Portal，选择 **Sunshine**
+![Bazzite Portal Menu Preview|400x300](../img/sunshine-bazzite-portal-menu.png)
+2. 选择 **Enable**
+![Bazzite Portal Submenu Preview|250x200](../img/sunshine-bazzite-portal-submenu.png)
+3. 应该会弹出一个终端窗口以进行安装步骤。安装完成后，需要输入一次用户密码来授权录屏等相关权限。
+4. 此时是个测试配置的好机会 - 先前安装时的配置应该会完整保留。
+
+## Bazzite Portal 快捷安装的限制
+
+Bazzite Portal 固定安装稳定版的 Sunshine Flatpak。如果你为了特定修复或其他原因需要测试版，则必须手动安装。
+!!! info "Bazzite Portal 目前仍保留安装**实验性**的 Homebrew 版 Sunshine 的功能，用于掌机版的配置，但是目前该版本在录屏功能和系统通知栏指示器等方面存在已知问题。"
+
+## 其他安装方式
+
+Sunshine 官方通过 COPR 提供 Fedora 的安装包。除此之外也有其他的安装方法，但各自可能存在一些限制。
+!!! warning "Bazzite 无法支持通过这些方式安装 Sunshine 的配置。如果发现问题，应直接报告到 Sunshine 或对应打包的项目下。"
+
+=== "将官方 COPR 包添加到系统树"
+    
+    结果上类似于 Sunshine 仍在镜像内时的配置。
+    使用以下命令将[官方版的稳定 COPR 包](https://copr.fedorainfracloud.org/coprs/lizardbyte/stable/)添加到系统树：
+    ```bash
+    sudo dnf5 copr enable lizardbyte/stable
+    rpm-ostree install Sunshine
+    ```
+    !!! info "Sunshine 官方的打包往往不对应 Fedora 的大版本更新，因此在更新落地 Bazzite 后一段时间往往会出现没有对应包可供安装的情况，这会导致系统更新自动失败！此时必须通过`rpm-ostree reset`来重置系统树并恢复更新。"
+
+=== "将社区 COPR 包添加到系统树"
+    
+    结果上类似于 Sunshine 仍在镜像内时的配置。
+    和官方 COPR 包相比，社区包明确面向 Fedora 的更新频率，对上游 Breaking change 有专门处理，并且面向 Fedora 和 Bazzite 都有测试，以保证更新间的稳定性。
+
+    使用以下命令将[社区维护的 COPR 包](https://copr.fedorainfracloud.org/coprs/pvermeer/sunshine/)添加到系统树：
+    ```bash
+    sudo dnf5 copr enable pvermeer/sunshine
+    rpm-ostree install sunshine
+    ```
+    !!! info "社区包由 *pvermeer* 维护，Bazzite 无法提供支持。"
+    
+## 安装 Sunshine 测试版
+
+Sunshine 测试版的 Flatpak 包不走已有的 Flatpak 仓库，因此必须手动配置，这会导致一些限制。
+!!! notice "Bazzite 无法支持通过这些方式安装 Sunshine 测试版的配置。如果发现问题，应直接报告到 Sunshine 或对应打包的项目下。"
+
+=== "手动安装测试版 Flatpak"
+
+    Sunshine 测试版的 Flatpak 包不在 flathub-beta 等仓库中，因此只能从 [GitHub 的版本发布页面](https://github.com/LizardByte/Sunshine/releases)手动下载。
+    1. 在你需要的版本下选择`Read more`；
+    2. 找到`sunshine_x86_64.flatpak`（或你所需要的其他架构）并下载，文件应默认下载到`~/Downloads/`目录下。
+    3. 运行以下命令：
+    ```bash
+    flatpak install --system ~/Downloads/sunshine_x86_64.flatpak
+    flatpak run --command=additional-install.sh dev.lizardbyte.app.Sunshine
+    systemctl --user enable --now app-dev.lizardbyte.app.Sunshine
+    ```
+    !!! info "之后每次更新版本，都需要重复这些步骤。"
+
+=== "将官方 COPR 包添加到系统树"
+    
+    结果上类似于 Sunshine 仍在镜像内时的配置。
+    使用以下命令将[官方的测试版 COPR 包](https://copr.fedorainfracloud.org/coprs/lizardbyte/beta/)添加到系统树：
+    ```bash
+    sudo dnf5 copr enable lizardbyte/beta
+    rpm-ostree install Sunshine
+    ```
+    !!! warning "和稳定版一样，如果 Sunshine 官方没有提供新的 Fedora 大版本的安装包，则到时候 Bazzite 的系统更新会自动失败。此时必须通过`rpm-ostree reset`来重置系统树并恢复更新。"
+
+=== "将社区 COPR 包添加到系统树"
+
+    使用以下命令将[社区维护的测试版 COPR 包](https://copr.fedorainfracloud.org/coprs/pvermeer/sunshine/)添加到系统树：
+    ```bash
+    sudo dnf5 copr enable pvermeer/sunshine
+    rpm-ostree install sunshine-beta
+    ```
+    !!! info "社区包由 *pvermeer* 维护，Bazzite 无法提供支持。"
+    
+=== "安装实验性的 Homebrew 包"
+
+    该方法主要面向掌机版用户。
+    在 Bazzite Portal 中选择 App Install 🡒 Sunshine 🡒 Enable Beta (Brew)。
+    !!! notice "该安装方法仍在实验阶段，并且目前存在录屏功能和系统通知栏指示器等方面的已知问题。当前 Bazzite Portal 进行的配置下，系统通知栏图标默认隐藏，且采用 KMS 进行录屏。"
+    
+## 在掌机版镜像上配置 Sunshine
+
+掌机版镜像下，**游戏模式**采用的是 Valve 的 Gamescope 微合成器，因此不支持基于 XDG Portal 或 Kwin Screencast 的录屏方式，所以只能使用 KMS 录屏。Flatpak 版的 Sunshine 目前无法支持 KMS，因此在游戏模式下必须使用其他方法安装 Sunshine 才能进行录屏。该限制不影响桌面模式。
+
+=== "安装实验性的 Homebrew 包"
+
+    在 Bazzite Portal 中选择 App Install 🡒 Sunshine 🡒 Enable Beta (Brew)。
+    !!! notice "该安装方法仍在实验阶段，并且目前存在录屏功能和系统通知栏指示器等方面的已知问题。当前 Bazzite Portal 进行的配置下，系统通知栏图标默认隐藏，且采用 KMS 进行录屏。"
+    
+=== "将官方 COPR 包添加到系统树"
+    
+    结果上类似于 Sunshine 仍在镜像内时的配置。
+    使用以下命令将[官方的 COPR 包](https://copr.fedorainfracloud.org/coprs/lizardbyte/stable/)添加到系统树：
+    ```bash
+    sudo dnf5 copr enable lizardbyte/stable
+    rpm-ostree install Sunshine
+    ```
+    !!! warning "如果 Sunshine 官方没有提供新的 Fedora 大版本的安装包，则到时候 Bazzite 的系统更新会自动失败。此时必须通过`rpm-ostree reset`来重置系统树并恢复更新。"
+
+=== "将社区 COPR 包添加到系统树"
+
+    使用以下命令将[社区维护的 COPR 包](https://copr.fedorainfracloud.org/coprs/pvermeer/sunshine/)添加到系统树：
+    ```bash
+    sudo dnf5 copr enable pvermeer/sunshine
+    rpm-ostree install sunshine
+    ```
+    !!! info "社区包由 *pvermeer* 维护，Bazzite 无法提供支持。"
+    
+## 安装方法比较
+
+| 方法                         | Flatpak （Bazzite Portal）                    | Brew （Bazzite Portal）                         | 将官方 COPR 安装到系统树                         | 将社区 COPR 安装到系统树                         |
+| :----------------------------: | :------------------------------------------ | :-------------------------------------------- | :------------------------------------------------ | :------------------------------------------------ |
+| 是否不影响系统更新？   | ✅ 纯用户级安装                  | ✅ 纯用户级安装                    | ❌ 官方有鸽子前科       | ℹ️ 由 **pvermeer** 维护         |
+| 能否锁定版本？ | ✅ 支持手动锁定                  | ✅ 默认锁定                  | ❌ `rpm-ostree` 限制[^1] | ❌ `rpm-ostree` 限制[^1] |
+| 是否支持 KMS 录屏？    | ❌ Flatpak 不支持必要的 `setcap` 功能          | ℹ️ NVIDIA 可能存在问题                  | ✅ 无已知问题                                | ✅ 无已知问题                                |
+| 版本是否稳定？                 | ✅ 默认安装稳定版                | ℹ️ 需要手动配置               | ❌ 官方有鸽子前科[^2]    | ✅ 社区维护的自动更新                 |
+| 是否提供测试版？                   | ℹ️ 必须手动配置更新 | ✅ 默认为测试版，且锁定版本 | ℹ️ 自动更新，可能有 Breaking change        | ✅ 社区维护的自动更新                 |
+| 支持状态            | ✅ 官方支持                      | ℹ️ 实验性，存在已知问题    | ❌ 官方有鸽子前科[^2]    | ✅ 社区维护的自动更新                 |
+
+[^1]: 理论上可以手动从 COPR 下载特定版本的 RPM 包并人工加进系统树，但这样每次更新都必须手动卸载再重装。
+[^2]: Sunshine 官方的 Fedora 包有过长期错过更新的情况（指没能赶上 Fedora 大版本更新时的 mass rebuild）。请参考[这一部分](/Advanced/sunshine/#what-is-happening-to-sunshine-on-bazzite)。
+
+综合各方面考量，目前选择的配置是在桌面版默认 Flatpak 安装，而在掌机版采用测试版的 Homebrew 安装。
+
+## 通过虚拟显示屏串流
+
+请参考[自定义分辨率](/Advanced/custom_resolution/#guide-for-creating-a-custom-resolution-for-sunshine-game-streaming)相关指南。
+    
+## 常见问题
+
+<hr>
+
+### Is a display connected and turned on? (error 503)
+
+该错误通常说明 Sunshine 在抓取屏幕时碰到问题。
+
+=== "KWin ScreenCast"
+
+    有些 KDE Plasma 和 Sunshine 的版本组合下，KWin ScreenCast 调用`zkde_screencast_unstable_v1`协议的权限定义存在问题。一个临时解决方法是定义`KWIN_WAYLAND_NO_PERMISSION_CHECKS=1`环境变量。[Bazzite Portal](/Installing_and_Managing_Software/Bazzite_Portal/) 下的 Install Applications → Setup Virtual Monitor → Fix Error 503 选项能够自动应用这一设置，或者在以下三处中任选一个进行设置：
+    
+    -   系统级设置：`/etc/environment.d/`
+    -   用户级设置：`~/.config/environment.d/`（Bazzite Portal 会设置在这里）
+    -   KDE Plasma 设置：`~/.config/plasma-workspace/env/kwin_vars.sh`
+    
+    !!! info "另外可以尝试在 KDE 系统设置 🡒 应用程序权限 🡒 Sunshine 下明确授权“远程控制”。"
+
+=== "Kernel Mode Setting"
+    
+    !!! warning "由于 Flatpak 沙盒的限制，KMS 录屏在 Flatpak 版 Sunshine 下**无法正常运作**。"
+    对于通过 Homebrew 安装的 Sunshine，这通常说明 Sunshine 的可执行文件没有调用 KMS 的权限。通过 Bazzite Portal 更新 Sunshine 通常能够解决该问题，或者手动运行`/usr/libexec/sunshine-postinst`这一安装后脚本。
+    
+=== "XDG Portal"
+
+    可以尝试删除 Sunshine 有关远程控制和屏幕录制的授权记录。再次触发时，XDG Desktop Portal 应该会弹出新窗口再次请求授权。
+    
+=== "其他录屏方法"
+    
+    !!! warning "基于 X11 的录屏方法不受支持。目前支持的录屏方法都是通过桌面环境提供的合成器（Kwin 或 Mutter）或直接通过 KMS。"
+    -   Bazzite 不支持纯 X11 的显示环境。
+    -   NvFBC 面向 X11，因此同样不受支持。
+    -   基于 wlroots 的 Wayland 合成器有一套单独的录屏协议，但目前 Bazzite 没有支持这些合成器的官方镜像。对于配置了这些合成器的自定义镜像，也许可以对应使用。
+
+<hr>
+
+### Error: Couldn't import RGB Image: 00003009 (error -1) 
+
+在安装了 NVIDIA 显卡的系统上，`systemctl --user status homebrew.sunshine*`可能会报告错误`Error: Couldn't import RGB Image: 00003009`。
+目前认为该错误是 Sunshine 和/或 CUDA 在 Homebrew 上的打包问题导致。一些可能的解决方法：
+
+-    更新 Bazzite，并通过 Bazzite Portal 改为 Flatpak 版 Sunshine；
+-    使用 **XDG Portal** 录屏时切换编码器；
+-    如果可用，手动指定录屏使用的显卡；
+-    通过其他安装方法改为使用测试版的 Sunshine。
+
+!!! info "Sunshine 上游也在研究这个问题。如果你找到了解决方法，请积极向上报告。"
+
+<hr>
+
+### The \`brew link\` step did not complete successfully
+
+这是 Homebrew 在 `/home` 为符号链接的 Linux 环境下的一个已知问题。
+!!! info "建议通过 Bazzite Portal 切换到 Flatpak 版，不论是稳定版还是测试版。"
+![Brew Link Fail Preview|400x200](../img/brew-link-fail.png)
+修复该问题需要手动创建 Homebrew 提示的**目标**文件夹，命令可能类似于：
+`mkdir -p /home/linuxbrew/.linuxbrew/Cellar/xkeyboard-config/2.47/share/xkeyboard-config-2`
+有些情况下强制重新`brew link`也能解决问题：
+`brew unlink xkeyboard-config; brew link --overwrite xkeyboard-config`
+    
+如果有其他问题，欢迎来 [Bazzite 的 Discord 服务器](/community.md)讨论。

--- a/src/Gaming/Common_gaming_issues.zh_CN.md
+++ b/src/Gaming/Common_gaming_issues.zh_CN.md
@@ -1,0 +1,133 @@
+---
+title: 游戏常见问题
+---
+
+# 游戏常见问题
+
+## 选择 Linux 原生版还是 Windows 版？
+
+有些游戏的 Linux 原生版可能会少一些功能或在性能上弱于通过 Proton 运行 Windows 版，但也有些游戏可能只能使用原生版，需要具体游戏具体分析。
+
+如果一个游戏提供了 Linux 原生版但它无法正常启动，可以尝试强制使用 **Legacy Runtime** 兼容性工具。在 Steam 的**游戏属性**下的**兼容性**菜单勾选 **Force the use of a specific Steam Play compatibility tool** 即可选择它。
+
+!!! warning "Counter Strike 2 **必须**使用 Linux 原生版运行（在 Steam 的游戏配置中禁用**Force the use of a specific Steam Play compatibility tool**）。运行 Proton 版的 CS2 可能会导致账户被 VAC 封禁。"
+
+## Denuvo 防篡改保护的游戏
+
+Denuvo 会将 Proton 版本的切换视为在新硬件上激活游戏，因此如果在 24 小时内切换超过 5 次将会导致激活失败，无法启动游戏。等待 24 小时后即可再次尝试。
+
+---
+
+## Source 1 引擎的音频或自定义内容
+
+!!! note
+
+    本章节只针对基于 [Source 引擎](https://www.pcgamingwiki.com/wiki/Engine:Source) 的游戏的相关问题。
+
+!!! attention
+
+    除非你确实碰到了这些音频或 _Left 4 Dead 2_ 相关的问题，否则不需要，也不应该执行这些步骤。
+
+在 Source 引擎的游戏中发现音频或自定义内容无法加载？问题在于 SELinux 阻止了 MP3 的解码以及其他一些组件的正常运行。本质原因是 Source 引擎在执行这些操作时[**将堆内存作为代码执行**](https://github.com/ValveSoftware/steam-for-linux/issues/43)了。Bazzite 基于 Fedora，因此默认启动 SELinux，这和基于 Arch Linux 的 SteamOS 不同。
+
+在 _Left 4 Dead 2_ 中自定义地图房间的创建和加入失败也可能是这个问题。
+
+### 音频或自定义内容的修复
+
+!!! 警告
+
+    SELinux 配置仅适合进阶用户操作。作为安全相关的内核底层组件，错误的配置可能会影响系统其他功能的正常运行，并降低系统安全性。
+
+为了修复这些音频和自定义内容的问题，必须通过解析已有的`hl2_linux`触发的 SELinux 安全日志，生成并加载一个 SELinux 模块，以将这些操作加入允许运行的白名单。
+
+<del>当你醒来，你会发现一切都变了......</del>
+
+=== "生成并安装策略模块"
+
+    ```bash
+    sudo -i
+    cd /tmp
+    ausearch -c 'hl2_linux' --raw | audit2allow -M my-hl2linux
+    semodule -X 300 -i my-hl2linux.pp
+    ```
+    如果没有解决，请尝试重启。
+
+=== "禁用策略模块"
+
+    ```bash
+    semodule -X 300 -d my-hl2linux
+    ```
+
+=== "移除策略模块"
+
+    ```bash
+    semodule -X 300 -r my-hl2linux
+    ```
+    生成模块的步骤会把对应的 `.pp` 文件生成在 `/root/` 目录下，如有需要可以手动删除。
+
+---
+
+## Steam 游戏无法启动
+
+Steam 游戏无法启动也有很多种情况。以下列出一些可能导致游戏立刻关闭或崩溃的问题（**开始游戏**按钮短暂显示**停止**之后很快跳回**开始游戏**）。
+
+### `gamemoderun`
+
+!!! note
+
+      这里讨论的不是 Bazzite 掌机版（bazzite-deck）提供的**游戏模式**。 而是向操作系统申请各种优化以提升游戏性能的工具 (Feral) GameMode。
+
+ProtonDB 上经常有用户建议将启动选项设定为`gamemoderun %command%`，但在 Bazzite 上这很可能导致游戏无法正常启动。
+
+我们建议直接将它移除，原因有三：<small>_人有五名，代价有三个......_</small>
+
+-   Bazzite 不预安装 GameMode，也不计划支持；
+-   GameMode 在较新硬件上带来的性能提升非常有限；
+-   有些极端情况下甚至会导致性能损失。
+
+It might work if you layer the `gamemode` package, but this is **NOT** supported.
+
+### NTFS 文件系统下的权限问题
+
+**不要把游戏安装在 NTFS 文件系统的分区上**。Windows 创建的宗卷通常是 NTFS 文件系统。[**此处**](./Hardware_compatibility_for_gaming.md#unsupported-filesystems-for-secondary-drives)提供了更多信息。
+
+### 多用户环境下使用 Wine
+
+!!! note
+
+    Bazzite 掌机版（bazzite-deck）不支持多个 Linux 用户的配置，因此本章节只适用于桌面版。
+
+有时如果你从另一个 Linux 用户启动 Steam 游戏，可能会出错。一个常见的原因似乎是 Wine Prefix 文件的所有权问题，其典型标志为新用户的` ~/.local/share/Steam/logs/console-linux.txt`下类似于这样的错误:
+
+```
+wineserver: /SteamLibrary/steamapps/compatdata/377160/pfx is not owned by you
+```
+
+一种解决方法是创建一个公用的 Steam library 来保存 Proton 需要的 Prefix 数据，并通过符号链接（_symlink_）将其他对应文件夹也映射到下面。
+
+```console
+USER2@bazzite: /mnt/ExtraStuff/USER2SteamLibrary/steamapps$ ls -la
+total 32
+drwxrwxr-x. 3 USER2 steamplayers 4096 Jan 29 15:19 .
+drwxrwsr-x. 3 USER2 steamplayers 4096 Jan 29 16:13 ..
+-rwxr-xr-x. 1 USER2 USER2         2287 Jan 29 15:19 appmanifest_377160.acf
+lrwxrwxrwx. 1 USER2 USER2           51 Jan 29 15:10 common -> /mnt/ExtraStuff/USER1SteamLibrary/steamapps/common/
+drwxr-xr-x. 3 USER2 USER2         4096 Jan 29 15:13 compatdata
+lrwxrwxrwx. 1 USER2 USER2           56 Jan 29 15:12 shadercache -> /mnt/ExtraStuff/USER1SteamLibrary/steamapps/shadercache/
+lrwxrwxrwx. 1 USER2 USER2           49 Jan 29 15:12 temp
+lrwxrwxrwx. 1 USER2 USER2           53 Jan 29 15:12 workshop
+```
+
+进一步的话，可以复制或链接各个库下的 appmanifest 文件，以保证每个 Steam library 都能看到游戏。
+
+---
+
+## 生成 Proton 日志
+
+如果通过 Proton 运行游戏时遇到问题，可以用以下步骤生成日志文件。
+
+1.  在 Steam 或 其他启动器的启动选项里配置[环境变量](/Gaming/launch-options-env-variables) `PROTON_LOG=1 %command%`；
+2.  再次启动游戏；
+3.  你的用户目录（`/home/[用户名]`）下应该会生成一个名字包含游戏的 Steam ID 命名的`.log`文件，类似于`steam-{App ID}.log`。
+
+在寻求支持或向 Valve 提供错误报告时，通常会需要这个文件。

--- a/src/Gaming/Common_gaming_issues.zh_CN.md
+++ b/src/Gaming/Common_gaming_issues.zh_CN.md
@@ -85,7 +85,7 @@ ProtonDB 上经常有用户建议将启动选项设定为`gamemoderun %command%`
 -   GameMode 在较新硬件上带来的性能提升非常有限；
 -   有些极端情况下甚至会导致性能损失。
 
-It might work if you layer the `gamemode` package, but this is **NOT** supported.
+你也许可以通过`rpm-ostree`安装`gamemode`包以提供该命令，但 Bazzite **无法提供相关支持**。
 
 ### NTFS 文件系统下的权限问题
 

--- a/src/Gaming/Game_Launchers.zh_CN.md
+++ b/src/Gaming/Game_Launchers.zh_CN.md
@@ -1,0 +1,59 @@
+---
+title: 游戏启动器
+---
+
+# 游戏启动器
+
+## 配置 Steam
+
+Steam 允许你在 Linux 上运行 Windows 游戏。这一过程使用 [**Proton**](https://github.com/ValveSoftware/Proton) 这一工具来实现 Windows 的兼容性。Proton 的本质是许多相关项目（比如 Wine）和特化补丁的集合，关于它的更多信息可以参考[这里](/Gaming/gaming-intro/#steam-games)。
+
+### Forcing A Specific Proton / Steam Play Tool Version
+
+#### 重要注意事项
+
+- 在 Bazzite 桌面版上，Steam 会优先使用 Linux 原生版（如果游戏提供的话）.
+- 在 Bazzite 掌机版上，Steam 会默认自动配置 Valve 官方推荐的 Steam Play 工具。
+- 有些游戏使用特定的 Proton 版本运行可能会比 Linux 原生版性能明显更好或更差，但必须具体游戏具体分析。
+
+如果需要特定的 Proton 版本，可以在游戏的 **Properties** → **Compatibility** 下选中 **Force the use of a specific Steam Play compatibility tool**，并在下拉框中选择你需要的版本。
+
+!!! warning "Counter Strike 2 **必须**使用 Linux 原生版运行（在 Steam 的游戏配置中禁用**Force the use of a specific Steam Play compatibility tool**）。运行 Proton 版的 CS2 可能会导致账户被 VAC 封禁。"
+
+#### 图例
+
+![齿轮图标 > 属性|690x284, 75%](../img/Steam_Setup_Cog.png)
+![“兼容性”选项卡|690x492, 75%](../img/Steam_Setup_Compat_Tab.png)
+
+
+## 非 Steam 游戏
+
+可以使用 Lutris （已预安装）或其他启动器，比如 [**Heroic Games Launcher**](https://flathub.org/en/apps/com.heroicgameslauncher.hgl) （适用于 GOG、Epic 或 Amazon 游戏）或者 [**Faugus**](https://flathub.org/en/apps/io.github.Faugus.faugus-launcher) ，它们都可以用于管理你的非 Steam 游戏的 Proton Prefix、Proton 版本和[启动选项](/Gaming/launch-options-env-variables/)。
+
+!!! note "通过 **Bazaar** 可以查找并安装不同的启动器。"
+
+!!! info "也可以直接把非 Steam 游戏添加到 Steam，此时 Prefix 由 Steam 直接管理。这在 Steam 游戏模式/大屏幕模式下会很有用。"
+
+### 设置
+
+通常来讲你只需要在 **Add locally installed game** 选项中选择游戏的 .exe 文件，启动器会自动创建 Proton Prefix 并进行管理。各个启动器一般也提供手动指定 Prefix 路径的选项，可以按需操作。
+
+!!! note "Lutris 通常提供两种在 Bazzite 上运行 Windows 游戏的选项：社区脚本或手动配置。由于有些社区脚本可能已过时或疏于维护，**一般建议手动配置**。"
+
+### 在 Lutris 里手动添加 Windows 游戏
+
+!!! 备注
+
+    其他启动器对应的操作和以下列出的步骤一般差别不会太大。
+
+![Add Locally Installed Game|632x496, 75%](../img/Lutris_Setup_Add_Local_Game.png)
+
+![Lutris manually adding games example 1|690x213](../img/Lutris_Setup_Add_Local_Game_1.png)
+
+By default, Lutris will use the `~/Games` directory for each game's [**prefix directory**](/Gaming/Managing_and_modding_games/#what-is-a-proton-or-wine-prefix).
+
+### Adding Shortcuts and Desktop Entries
+
+![Lutris_Right_Click_Menu|421x447, 75%](../img/Lutris_Setup_Shortcut.png)
+
+You may add a shortcut for the game into the App Menu or your Desktop by going into the Edit Tab or the Right Click Context Menu of the launcher of your choice and selecting the respective entries.

--- a/src/Gaming/Game_Launchers.zh_CN.md
+++ b/src/Gaming/Game_Launchers.zh_CN.md
@@ -8,7 +8,7 @@ title: 游戏启动器
 
 Steam 允许你在 Linux 上运行 Windows 游戏。这一过程使用 [**Proton**](https://github.com/ValveSoftware/Proton) 这一工具来实现 Windows 的兼容性。Proton 的本质是许多相关项目（比如 Wine）和特化补丁的集合，关于它的更多信息可以参考[这里](/Gaming/gaming-intro/#steam-games)。
 
-### Forcing A Specific Proton / Steam Play Tool Version
+### 指定特定的 Proton / Steam Play 版本
 
 #### 重要注意事项
 
@@ -50,10 +50,10 @@ Steam 允许你在 Linux 上运行 Windows 游戏。这一过程使用 [**Proton
 
 ![Lutris manually adding games example 1|690x213](../img/Lutris_Setup_Add_Local_Game_1.png)
 
-By default, Lutris will use the `~/Games` directory for each game's [**prefix directory**](/Gaming/Managing_and_modding_games/#what-is-a-proton-or-wine-prefix).
+Lutris 默认将每个游戏的 [**Prefix**](/Gaming/Managing_and_modding_games/#what-is-a-proton-or-wine-prefix) 保存在`~/Games`目录下。
 
-### Adding Shortcuts and Desktop Entries
+### 添加快捷方式和桌面条目
 
 ![Lutris_Right_Click_Menu|421x447, 75%](../img/Lutris_Setup_Shortcut.png)
 
-You may add a shortcut for the game into the App Menu or your Desktop by going into the Edit Tab or the Right Click Context Menu of the launcher of your choice and selecting the respective entries.
+通常可以通过启动器的编辑功能或右键点击游戏条目中的对应选项，为一个游戏添加快捷方式。

--- a/src/Gaming/Hardware_compatibility_for_gaming.zh_CN.md
+++ b/src/Gaming/Hardware_compatibility_for_gaming.zh_CN.md
@@ -1,0 +1,130 @@
+---
+title: 游戏与硬件兼容性
+---
+
+# 游戏与硬件兼容性
+
+## 最低系统要求
+
+- **引导固件**: UEFI （[**不支持**](../General/FAQ.md#does-bazzite-support-csmlegacy-boot) CSM/BIOS 启动）
+- **处理器（CPU）** : 2GHz，四核
+  - **架构**: x86-64
+- **内存（RAM）**: 8GB
+- **显卡**: 支持 Vulkan 1.3 或更高
+- **存储**: 内置**固态硬盘（SSD）**上 50GB 的可用空间
+  - **推荐配置**: 内置**固态硬盘（SSD）**上 120GB 的可用空间
+  - 硬盘必须为 **GUID 分区表（GPT）**格式。在主启动记录（MBR）硬盘上安装 Bazzite 会出错。
+    - Microsoft 在 Windows 上提供了[将已有的 MBR 硬盘无损转换为 GPT 格式的实用工具](https://learn.microsoft.com/en-us/windows/deployment/mbr-to-gpt)。
+    !!! warning "在进行任何硬盘更改操作之前，请务必备份所有重要的个人文件。"
+  - **外置或其他非系统盘**: 必须使用 **BTRFS**（固态硬盘）或 **Ext4**（机械硬盘）。 _将文件转移后，可以在安装完成之后进行格式化。_
+  > 更多信息请参考[这一部分](#unsupported-filesystems-for-secondary-drives)。
+- **网络连接**: 稳定的有线或无线连接。 _安装时不需要。_
+
+!!! note
+
+    有些外设硬件与 Linux 不兼容，因此无法和 Bazzite 配合使用，具体的兼容情况通常取决于厂商。对于 USB 连接的无线网卡，可以参考[这篇确认兼容的硬件列表](https://github.com/morrownr/USB-WiFi/blob/main/home/USB_WiFi_Adapters_that_are_supported_with_Linux_in-kernel_drivers.md)。
+
+>[**Hardware for Linux**](https://linux-hardware.org/?view=computers) 这个网站提供了一些 OEM 型号的电脑和 Linux 的兼容性的相关信息。
+
+### Steam 游戏模式的系统要求
+
+!!! note
+
+    这些要求只适用于 [Bazzite 掌机版](/Handheld_and_HTPC_edition/Steam_Gaming_Mode.md)（bazzite-deck），和 [SteamOS](https://store.steampowered.com/steamos/) 的要求基本一致。
+
+- 较新的 AMD 显卡
+  - RX 4xx 系及以上
+    - 也支持 Radeon 600M/700M/8000S 等 APU 集显
+- Intel Arc 显卡（和 AMD 相比存在**少量问题**）
+- NVIDIA 显卡（理论能跑但存在[**严重问题**](/Handheld_and_HTPC_edition/quirks/#nvidia-gpu-exclusive-issues-with-steam-gaming-mode)） 
+  - 这些问题为 NVIDIA 驱动在 Linux 端本身的问题，因此无法在 Bazzite 一侧解决
+- [**Steam**](https://store.steampowered.com/) 账号
+  - 如果目前没有账号，也可以在安装完成后在系统开机时注册
+
+### Compatible Handhelds
+
+The [**Handheld Wiki**](../Handheld_and_HTPC_edition/Handheld_Wiki/index.md) lists tested handhelds with proper support, including the Steam Deck, ASUS ROG Ally, Lenovo Legion Go, and a handful of other handhelds.
+
+<hr>
+
+## 支持 Vulkan 的显卡
+
+!!! attention
+
+    Linux 端运行游戏很大程度上依赖显卡对 [Vulkan](/General/terms/#software) 的支持。
+
+### 查询显卡支持的 Vulkan 版本
+
+有些较老的显卡可能只支持 **Vulkan 1.1 or 1.2**，但不支持 **Vulkan 1.3 或更新版本**。此时可能需要 Proton-CachyOS 配合 DXVK-Sarek，具体指南见下。在**终端**中输入这条命令来查询你的显卡支持的 Vulkan 版本：
+
+```bash
+vulkaninfo | grep 'Instance Version'
+```
+
+![Vulkan Command](https://github.com/user-attachments/assets/ccca14ca-3001-4aa6-bf47-e0dcbdb73936)
+
+- 如果输出中`Vulkan Instance Version:`一行给出的值低于 1.3 或出现其他错误，则你的显卡不支持 Vulkan 1.3。这很可能会导致各类游戏出现问题或性能损失。
+
+- 更老一些的显卡可能必须回退到 OpenGL 转译而非 Vulkan，这往往会导致进一步的问题或性能损失。
+
+> 对于只支持 Vulkan 1.1 或 1.2 的显卡，有时可以使用 [**DXVK-Sarek**](https://github.com/pythonlover02/DXVK-Sarek) 进行 Vulkan 转译。 [Proton-CachyOS](https://github.com/CachyOS/proton-cachyos) 默认支持通过`PROTON_DXVK_SAREK=1`[环境变量](/Gaming/launch-options-env-variables)启用，但请注意这可能会触发联机游戏或各类反作弊组件的警告。
+
+!!! info "ProtonPlus 和 ProtonUp-Qt 都可以用于安装 [Proton-CachyOS](https://github.com/CachyOS/proton-cachyos) 或其他版本的 Proton。"
+
+### 不支持 Vulkan 的显卡
+
+对于完全不支持 Vulkan 的显卡，必须为**所有通过 Proton 运行的游戏**设置以下启动选项：
+
+```bash
+PROTON_USE_WINED3D=1 %command%
+```
+
+这将强制游戏进行 OpenGL 而非 Vulkan 转译。
+
+<hr>
+
+## 文件系统
+
+!!! note
+
+    Bazzite 默认自动挂载使用 Ext4 和 BTRFS 文件系统的外接硬盘。
+
+**BTRFS 是 Bazzite 默认选择并推荐使用的文件系统**。任何计划在 Bazzite 上使用并存储游戏的分区都应该使用**Ext4 或 BTRFS**文件系统，但**格式化的过程会不可逆清除所有数据**。[**可以使用 GNOME Disks 按需进行格式化**](../Advanced/Auto-Mounting_Secondary_Drives.md)，但请务必注意不要丢失数据。
+
+!!! warning "格式化一个分区会清除上面的所有数据，且无法撤销。"
+
+### Unsupported Filesystems for Secondary Drives
+
+!!! warning
+
+    NTFS and exFAT/FAT32 are NOT SUPPORTED. These filesystems can and will eventually lead to DATA CORRUPTION under Linux, and/or does not support the features needed for Proton/WINE. Do NOT use them!
+    WinBTRFS still have BUGS, and the file permission/ownership system on Windows is very different to that of Linux, with no guarantee that you won't run into issues and/or data loss later down the road.
+    
+    All of this means that there is Unfortunately no reliable cross-platform filesystem that can be shared between Windows and Linux.
+
+!!! warning "格式化一个分区会清除上面的所有数据，且无法撤销。"
+    
+!!! info
+    
+    To disable the NTFS nag, run `ujust _disable-ntfs-service`. **ONLY DO THIS IF YOU KNOW WHAT YOU ARE DOING. THIS WILL NOT PREVENT DATA LOSS, ONLY DISABLE THE WARNING.**
+
+
+#### NTFS
+
+If you are coming from Windows and plan to game on a secondary drive with games already installed on it, then we regret to inform you that the NTFS filesystem is **unsupported** for PC gaming on Bazzite.
+
+Playing games off of NTFS causes various issues, including but not limited to **games not launching at all**, and will eventually result in **data corruption** and **permanent data loss**!
+
+#### exFAT 和 FAT32
+
+FAT32 and exFAT are **unsupported**. Both filesystems **do not support symbolic links** which is required for Proton prefixes to work properly.  However, there are scenarios where a microSD card is formatted to exFAT _may work_ in some cases, but this method is unsupported as something the Bazzite maintainers do not plan to accommodate.
+
+Additionally, the FAT family of filesystems are not [Journaling file systems](https://en.wikipedia.org/wiki/Journaling_file_system). This means data loss or corruption on FAT is more likely to happen, with recovery being much, much harder. Therefore, Bazzite also advises to avoid storing important data without backups on FAT filesystems.
+
+### 和双启动的 Windows 共用游戏库
+
+Install the unofficial [WinBtrfs](https://github.com/maharmstone/btrfs) driver on your Windows installation **at your own risk**. Please make sure to read any documentation associated with this project before installing the driver on Windows.
+
+#### Video Tutorial
+
+https://www.youtube.com/watch?v=h6fc-3CCXbA

--- a/src/Gaming/Hardware_compatibility_for_gaming.zh_CN.md
+++ b/src/Gaming/Hardware_compatibility_for_gaming.zh_CN.md
@@ -41,9 +41,9 @@ title: 游戏与硬件兼容性
 - [**Steam**](https://store.steampowered.com/) 账号
   - 如果目前没有账号，也可以在安装完成后在系统开机时注册
 
-### Compatible Handhelds
+### 兼容的掌机
 
-The [**Handheld Wiki**](../Handheld_and_HTPC_edition/Handheld_Wiki/index.md) lists tested handhelds with proper support, including the Steam Deck, ASUS ROG Ally, Lenovo Legion Go, and a handful of other handhelds.
+[**Handheld Wiki**](../Handheld_and_HTPC_edition/Handheld_Wiki/index.md) 列出了进行了测试且支持的的掌机型号，包括了 Steam Deck、ASUS ROG Ally、Lenovo Legion Go 等。
 
 <hr>
 
@@ -93,33 +93,33 @@ PROTON_USE_WINED3D=1 %command%
 
 !!! warning "格式化一个分区会清除上面的所有数据，且无法撤销。"
 
-### Unsupported Filesystems for Secondary Drives
+### 外接硬盘上不支持的文件系统
 
 !!! warning
 
-    NTFS and exFAT/FAT32 are NOT SUPPORTED. These filesystems can and will eventually lead to DATA CORRUPTION under Linux, and/or does not support the features needed for Proton/WINE. Do NOT use them!
-    WinBTRFS still have BUGS, and the file permission/ownership system on Windows is very different to that of Linux, with no guarantee that you won't run into issues and/or data loss later down the road.
+    NTFS 和 exFAT/FAT32 **不受支持**。这些文件系统在 Linux 上长期使用**一定**会导致无法在 Linux 上修复的数据损坏，且无法支持 Proton/WINE 需要的一些文件系统功能。不要将游戏安装在这些文件系统上！
+    WinBTRFS 也并非完美，且由于 Windows 和 Linux 在文件权限管理上的重大差异，无法保证数据的安全性。
     
-    All of this means that there is Unfortunately no reliable cross-platform filesystem that can be shared between Windows and Linux.
+    换句话说，目前并不存在一个足够可靠的，能同时用于 Windows 和 Linux 的文件系统。
 
 !!! warning "格式化一个分区会清除上面的所有数据，且无法撤销。"
     
 !!! info
     
-    To disable the NTFS nag, run `ujust _disable-ntfs-service`. **ONLY DO THIS IF YOU KNOW WHAT YOU ARE DOING. THIS WILL NOT PREVENT DATA LOSS, ONLY DISABLE THE WARNING.**
+    使用`ujust _disable-ntfs-service`命令隐藏 NTFS 挂载时的警告。**这并不能阻止数据损坏，只是隐藏提示信息。**
 
 
 #### NTFS
 
-If you are coming from Windows and plan to game on a secondary drive with games already installed on it, then we regret to inform you that the NTFS filesystem is **unsupported** for PC gaming on Bazzite.
+如果你先前使用的是 Windows 并且有在 Windows 下配置的安装了游戏的外接硬盘， If you are coming from Windows and plan to game on a secondary drive with games already installed on it, then we regret to inform you that the NTFS filesystem is **unsupported** for PC gaming on Bazzite.
 
 Playing games off of NTFS causes various issues, including but not limited to **games not launching at all**, and will eventually result in **data corruption** and **permanent data loss**!
 
 #### exFAT 和 FAT32
 
-FAT32 and exFAT are **unsupported**. Both filesystems **do not support symbolic links** which is required for Proton prefixes to work properly.  However, there are scenarios where a microSD card is formatted to exFAT _may work_ in some cases, but this method is unsupported as something the Bazzite maintainers do not plan to accommodate.
+FAT32 和 exFAT 都**不受支持**。两者都 **不支持符号链接**，因此 Proton Prefix 无法正常工作。不过，有些情况下可能会将一块 MicroSD 卡格式化成 exFAT 用于数据存储。这种做法有其意义，但 Bazzite 不计划提供支持。
 
-Additionally, the FAT family of filesystems are not [Journaling file systems](https://en.wikipedia.org/wiki/Journaling_file_system). This means data loss or corruption on FAT is more likely to happen, with recovery being much, much harder. Therefore, Bazzite also advises to avoid storing important data without backups on FAT filesystems.
+除此之外，FAT 体系的文件系统都不是 [日志式](https://en.wikipedia.org/wiki/Journaling_file_system)，因此出现数据损坏时将更难恢复。 Bazzite 不建议将重要数据保存在 FAT 文件系统中。
 
 ### 和双启动的 Windows 共用游戏库
 

--- a/src/Gaming/Hardware_compatibility_for_gaming.zh_CN.md
+++ b/src/Gaming/Hardware_compatibility_for_gaming.zh_CN.md
@@ -111,9 +111,9 @@ PROTON_USE_WINED3D=1 %command%
 
 #### NTFS
 
-如果你先前使用的是 Windows 并且有在 Windows 下配置的安装了游戏的外接硬盘， If you are coming from Windows and plan to game on a secondary drive with games already installed on it, then we regret to inform you that the NTFS filesystem is **unsupported** for PC gaming on Bazzite.
+如果你先前使用的是 Windows 并且有在 Windows 下配置的安装了游戏的外接硬盘，有个坏消息：Bazzite **无法支持**安装在 NTFS 文件系统上的游戏。
 
-Playing games off of NTFS causes various issues, including but not limited to **games not launching at all**, and will eventually result in **data corruption** and **permanent data loss**!
+游戏安装在 NTFS 分区上时会产生许多问题，包括**完全无法启动**等，且一定会导致难以修复的数据损坏。
 
 #### exFAT 和 FAT32
 
@@ -123,8 +123,8 @@ FAT32 和 exFAT 都**不受支持**。两者都 **不支持符号链接**，因�
 
 ### 和双启动的 Windows 共用游戏库
 
-Install the unofficial [WinBtrfs](https://github.com/maharmstone/btrfs) driver on your Windows installation **at your own risk**. Please make sure to read any documentation associated with this project before installing the driver on Windows.
+非官方的 [WinBtrfs](https://github.com/maharmstone/btrfs) 项目提供了在 Windows 上操作 BTRFS 文件系统的驱动程序，但使用时应注意数据风险。在安装前，请务必阅读项目提供的文档及相关注意事项。
 
-#### Video Tutorial
+#### 视频指南
 
 https://www.youtube.com/watch?v=h6fc-3CCXbA

--- a/src/Gaming/gaming-intro.zh_CN.md
+++ b/src/Gaming/gaming-intro.zh_CN.md
@@ -4,25 +4,25 @@ title: Bazzite 游戏入门
 
 # Bazzite 游戏入门
 
-## Paradigm Shift
+## 趋势转变
 
 在 Linux 上成体系的运行 Windows 游戏算是一个相对新的概念，但目前很多只面向 Windows 的游戏都已经可以在大致同等硬件配置的 Bazzite 上运行。虽然仍有些游戏存在一些障碍，但 Linux 有时也能提供更好的帧率或其他优势。
 
 ### Steam 游戏
 
-Steam is the recommended way to play PC games on Bazzite as it ships with a compatibility layer known as [**Proton**](/General/terms#software). Most singleplayer PC games should be runnable without any tweaking necessary, though there are cases where a game purchased and installed through Steam will not run out of the box. 
+Steam 通常是在 Bazzite 上运行 Windows 游戏最简单的方式，因为它自带了被称为 [**Proton**](/General/terms#software) 的兼容层。绝大多数单机游戏可以直接运行，但也有极少数游戏需要特定的配置调整。
 
-Some newer online multiplayer games require deeper access to your computer hardware and Windows drivers to run their anti-cheat software which may be blocked from running on Linux, meaning these games will be unplayable except on Windows.
+有些游戏，尤其是需要联机功能的游戏，可能会需要更底层的硬件权限来实现反作弊等功能。这些功能在 Windows 上通常由专有的驱动程序实现，但 Linux 不支持这种驱动，因此这些游戏很可能只能在 Windows 上运行。
 
 ### 非 Steam 游戏
 
 <small>_With this, we have included everything in the observable universe into Bazzite Docs, from Steam-Games... to Non Steam-Games. Q.E.D._</small>
 
-Bazzite 预安装了 **Lutris** 以管理非 Steam 的游戏，它也同样提供 Proton/Wine 管理的功能。 [**Faugus Launcher**](https://flathub.org/en/apps/io.github.Faugus.faugus-launcher) is an alternative to Lutris available in the Bazaar app store which may be favorable due to a simpler design than Lutris. [**Heroic Games Launcher**](https://flathub.org/apps/com.heroicgameslauncher.hgl) is recommended over Lutris for games that were purchased from Epic Games Launcher, GOG, and Amazon Games Launcher.
+Bazzite 预安装了 **Lutris** 以管理非 Steam 的游戏，它也同样提供 Proton/Wine 管理的功能。Bazaar 上也能找到 [**Faugus Launcher**](https://flathub.org/en/apps/io.github.Faugus.faugus-launcher)，提供相对更简洁的用户界面。对于通过 Epic Games Launcher、GOG 和 Amazon Games Launcher 运行的游戏，[**Heroic Games Launcher**](https://flathub.org/apps/com.heroicgameslauncher.hgl) 会更加合适。
 
-在 Windows 上通过 Microsoft Store 安装的游戏**无法**在 Bazzite 上直接运行。如果你有 Game Pass Ultimate 订阅的话，可以通过 Xbox Cloud Gaming 配合 [**Greenlight**](https://github.com/unknownskl/greenlight) 或类似的客户端来进行云游戏。Fortnite 不需要订阅亦可用这种方式运行。[**一些在 Game Pass 上可用的暴雪游戏**](https://us.support.blizzard.com/en/help/article/000367382)可以通过 Lutris 直接安装。
+在 Windows 上通过 Microsoft Store 安装的游戏**无法**在 Bazzite 上直接运行。如果你有 Game Pass Ultimate 订阅的话，可以通过 Xbox Cloud Gaming 配合 [**Greenlight**](https://github.com/unknownskl/greenlight) 或类似的客户端来进行云游戏。Fortnite 不需要订阅亦可用这种方式运行。[**一些在 Game Pass 上可用的暴雪战网游戏**](https://us.support.blizzard.com/en/help/article/000367382)可以通过 Lutris 直接安装。
 
-Console emulators can be installed from Bazaar or through projects like [**Retrodeck**](https://flathub.org/en/apps/net.retrodeck.retrodeck) or [**Emudeck**](https://www.emudeck.com/) (Available in the Bazzite Portal application).
+游戏主机的模拟器通常可以在 Bazaar 上找到，或者通过 [**Retrodeck**](https://flathub.org/en/apps/net.retrodeck.retrodeck) 或 [**Emudeck**](https://www.emudeck.com/) 一类的项目进行集中管理。Bazzite Portal 也提供了一些相关的快捷脚本。
 
 <hr>
 
@@ -30,8 +30,8 @@ Console emulators can be installed from Bazaar or through projects like [**Retro
 
 -   [**ProtonDB**](https://www.protondb.com/explore) - 玩家上传的 Linux 兼容性报告 
 -   [**Are We Anti-Cheat Yet?**](https://areweanticheatyet.com/) - 记录一些热门游戏的反作弊组件及其 Linux 支持情况
--   [**Linux Gaming Wiki**](https://linux-gaming.kwindu.eu/index.php?title=Main_Page) - Introduction to Linux gaming that includes helpful links
--   [**PC Gaming Wiki**](https://www.pcgamingwiki.com/wiki/Home) - General information, workarounds, and enhancements for PC games
--   [**General Emulation Wiki**](https://emulation.gametechwiki.com/index.php/Main_Page) - Emulation resources
--   [**Linux VR Adventures Wiki**](https://lvra.gitlab.io/) - General information for running VR games on Linux
--   [**Linux VR Adventure Database**](https://db.vronlinux.org/) - User reports for Virtual Reality (VR) game compatibility on Linux
+-   [**Linux Gaming Wiki**](https://linux-gaming.kwindu.eu/index.php?title=Main_Page) - Linux 游戏的总指南，也提供一些有用的参考链接
+-   [**PC Gaming Wiki**](https://www.pcgamingwiki.com/wiki/Home) - PC 游戏的总指南，也提供一些常见问题的修复指南和高级技巧
+-   [**General Emulation Wiki**](https://emulation.gametechwiki.com/index.php/Main_Page) - 模拟器相关资源
+-   [**Linux VR Adventures Wiki**](https://lvra.gitlab.io/) - 在 Linux 上运行虚拟现实（VR）游戏的相关信息
+-   [**Linux VR Adventure Database**](https://db.vronlinux.org/) - 玩家上传的 Linux 端 VR 游戏的兼容性报告

--- a/src/Gaming/gaming-intro.zh_CN.md
+++ b/src/Gaming/gaming-intro.zh_CN.md
@@ -1,0 +1,37 @@
+---
+title: Bazzite 游戏入门
+---
+
+# Bazzite 游戏入门
+
+## Paradigm Shift
+
+在 Linux 上成体系的运行 Windows 游戏算是一个相对新的概念，但目前很多只面向 Windows 的游戏都已经可以在大致同等硬件配置的 Bazzite 上运行。虽然仍有些游戏存在一些障碍，但 Linux 有时也能提供更好的帧率或其他优势。
+
+### Steam 游戏
+
+Steam is the recommended way to play PC games on Bazzite as it ships with a compatibility layer known as [**Proton**](/General/terms#software). Most singleplayer PC games should be runnable without any tweaking necessary, though there are cases where a game purchased and installed through Steam will not run out of the box. 
+
+Some newer online multiplayer games require deeper access to your computer hardware and Windows drivers to run their anti-cheat software which may be blocked from running on Linux, meaning these games will be unplayable except on Windows.
+
+### 非 Steam 游戏
+
+<small>_With this, we have included everything in the observable universe into Bazzite Docs, from Steam-Games... to Non Steam-Games. Q.E.D._</small>
+
+Bazzite 预安装了 **Lutris** 以管理非 Steam 的游戏，它也同样提供 Proton/Wine 管理的功能。 [**Faugus Launcher**](https://flathub.org/en/apps/io.github.Faugus.faugus-launcher) is an alternative to Lutris available in the Bazaar app store which may be favorable due to a simpler design than Lutris. [**Heroic Games Launcher**](https://flathub.org/apps/com.heroicgameslauncher.hgl) is recommended over Lutris for games that were purchased from Epic Games Launcher, GOG, and Amazon Games Launcher.
+
+在 Windows 上通过 Microsoft Store 安装的游戏**无法**在 Bazzite 上直接运行。如果你有 Game Pass Ultimate 订阅的话，可以通过 Xbox Cloud Gaming 配合 [**Greenlight**](https://github.com/unknownskl/greenlight) 或类似的客户端来进行云游戏。Fortnite 不需要订阅亦可用这种方式运行。[**一些在 Game Pass 上可用的暴雪游戏**](https://us.support.blizzard.com/en/help/article/000367382)可以通过 Lutris 直接安装。
+
+Console emulators can be installed from Bazaar or through projects like [**Retrodeck**](https://flathub.org/en/apps/net.retrodeck.retrodeck) or [**Emudeck**](https://www.emudeck.com/) (Available in the Bazzite Portal application).
+
+<hr>
+
+## 其他资源
+
+-   [**ProtonDB**](https://www.protondb.com/explore) - 玩家上传的 Linux 兼容性报告 
+-   [**Are We Anti-Cheat Yet?**](https://areweanticheatyet.com/) - 记录一些热门游戏的反作弊组件及其 Linux 支持情况
+-   [**Linux Gaming Wiki**](https://linux-gaming.kwindu.eu/index.php?title=Main_Page) - Introduction to Linux gaming that includes helpful links
+-   [**PC Gaming Wiki**](https://www.pcgamingwiki.com/wiki/Home) - General information, workarounds, and enhancements for PC games
+-   [**General Emulation Wiki**](https://emulation.gametechwiki.com/index.php/Main_Page) - Emulation resources
+-   [**Linux VR Adventures Wiki**](https://lvra.gitlab.io/) - General information for running VR games on Linux
+-   [**Linux VR Adventure Database**](https://db.vronlinux.org/) - User reports for Virtual Reality (VR) game compatibility on Linux

--- a/src/Gaming/gaming-intro.zh_CN.md
+++ b/src/Gaming/gaming-intro.zh_CN.md
@@ -16,7 +16,7 @@ Steam 通常是在 Bazzite 上运行 Windows 游戏最简单的方式，因为�
 
 ### 非 Steam 游戏
 
-<small>_With this, we have included everything in the observable universe into Bazzite Docs, from Steam-Games... to Non Steam-Games. Q.E.D._</small>
+<small>_至此，从 Steam 游戏到非 Steam 的一切都已加入 Bazzite <del>豪华午餐</del>指南。世界的真理，我已解明！_</small>
 
 Bazzite 预安装了 **Lutris** 以管理非 Steam 的游戏，它也同样提供 Proton/Wine 管理的功能。Bazaar 上也能找到 [**Faugus Launcher**](https://flathub.org/en/apps/io.github.Faugus.faugus-launcher)，提供相对更简洁的用户界面。对于通过 Epic Games Launcher、GOG 和 Amazon Games Launcher 运行的游戏，[**Heroic Games Launcher**](https://flathub.org/apps/com.heroicgameslauncher.hgl) 会更加合适。
 

--- a/src/Gaming/index.zh_CN.md
+++ b/src/Gaming/index.zh_CN.md
@@ -1,0 +1,13 @@
+---
+title: 游戏相关指南
+---
+
+# 游戏相关指南
+
+
+- [**Bazzite 游戏入门**](gaming-intro.md)
+- [**游戏与硬件兼容性**](Hardware_compatibility_for_gaming.md)
+- [**游戏启动器**](Game_Launchers.md)
+- [**游戏和模组管理**](Managing_and_modding_games.md)
+- [**启动选项与环境变量**](launch-options-env-variables.md)
+- [**游戏常见问题**](Common_gaming_issues.md)

--- a/src/Gaming/launch-options-env-variables.zh_CN.md
+++ b/src/Gaming/launch-options-env-variables.zh_CN.md
@@ -76,28 +76,28 @@ Bazzite 针对一些常用的启动选项提供了一些捷径。
 
 #### 如何设置启动选项
 
-1. 在 Steam library 内右键选择一个游戏
-2. 选择**属性**
-3. In the General tab, find **Launch Options** field
+1. 在 Steam 库中右键选择一个游戏
+2. 选择**属性...**
+3. 在**通用**一栏中，找到**启动选项**的输入框
 4. 输入你需要的启动选项
 
-![Launch Options view|833x594, 75%](../img/Steam_Launch_Options.png)
+![启动选项|833x594, 75%](../img/Steam_Launch_Options.png)
 
 ## 帧率限制相关问题
 
-游戏模式（gamescope）支持多种帧率限制的方式，但根据游戏与硬件配置，并非所有方法都稳定有效。
+游戏模式（Gamescope）支持多种帧率限制的方式，但根据游戏与硬件配置，并非所有方法都稳定有效。
 
 帧率限制的效果有时并不稳定，尤其是在桌面模式下。
 
-The tables below show the behavior of different framerate limiting methods.
+以下列出了一些常用的帧率限制方法和对应表现。
 
-=== "Steam Game Mode (Steam Gaming Mode Session)"
+=== "Steam 游戏模式（Gamescope 会话）"
 
     | 方法 | 如何设置 | 是否需要游戏内启用垂直同步？ | 不重启游戏能否生效？ | 对延迟的影响 | 是否推荐 | 备注 |
     |---|---|---|---|---|---|---|
-    | **Gamescope FPS limiter** | Use **Quick Access Menu → Performance → Framerate Limit** | No | Yes | Generally Worse | **Preferred** | Automatically enables v-sync at driver-level whenever the framerate cap is enabled. Additional latency will be introduced. |
-    | **MangoAPP (embedded)** | - | - | - | - | – | N/A - doesn't work at all. |
-    | **MangoHUD (external)** | **Launch Options:** `MANGOHUD=1 %command%` | No | Yes | Generally Worse | – | Set `fps_limit=0,{fps}...` (`0`=no cap) in `MangoHud.conf` or use [MangoJuice](https://flathub.org/en/apps/io.github.radiolamp.mangojuice). |
+    | **Gamescope 自带帧率限制** | Use **Quick Access Menu → Performance → Framerate Limit** | No | Yes | Generally Worse | **Preferred** | Automatically enables v-sync at driver-level whenever the framerate cap is enabled. Additional latency will be introduced. |
+    | **MangoAPP（Gamescope 集成）** | - | - | - | - | – | 默认会话无法添加需要的参数，因此不可用。 |
+    | **MangoHUD（外部安装）** | **游戏启动选项**：`MANGOHUD=1 %command%` | 否 | 是 | 相对较差 | – | 在`MangoHud.conf` 中进行配置（`fps_limit=0,{fps}...`，0对应无限制），或使用 [MangoJuice](https://flathub.org/en/apps/io.github.radiolamp.mangojuice)。 |
     | **DXVK/VKD3D runtime frame limiter** | **DXVK(D3D8/9/10/11):** `DXVK_FRAME_RATE={fps} %command%`<br>**VKD3D(D3D12):** `VKD3D_FRAME_RATE={fps} %command%` | No | No | Generally Better | – | Applies only to DXVK/VKD3D titles (no effect on native OpenGL or Vulkan games). |
 
 === "桌面模式 （GNOME/KDE Plasma 桌面会话）"

--- a/src/Gaming/launch-options-env-variables.zh_CN.md
+++ b/src/Gaming/launch-options-env-variables.zh_CN.md
@@ -1,0 +1,127 @@
+---
+title: 启动选项与环境变量
+---
+
+# 启动选项与环境变量
+
+## 前言
+
+近几年 Linux 上的游戏运行已经比以往方便了很多。当然，对于需要一些特定运行选项或配置的情况，Bazzite 也同样支持。这部分指南将简单总结一些可以在 Bazzite 上进行的高级配置。
+
+## DXVK、MangoHud 和 vkBasalt 的配置文件模板
+
+![模板文件|690x334, 50%](../img/DXVK_Mango_VkBasalt_templ.png)
+
+在 Bazzite 上可以利用这些模板文件快速创建一些常用工具所需要的配置文件。只需要在文件管理器的任意处右键点击即可。除此之外，也有 [**Mango Juice**](https://flathub.org/en/apps/io.github.radiolamp.mangojuice) 这样的程序提供配置 Mangohud 的图形界面。
+
+## Steam 启动选项与实用工具
+
+Steam 启动选项允许你向游戏传递环境变量、参数或额外命令。Bazzite 额外提供了一些实用程序和界面优化来帮助你完成一些常用操作，这在掌机上的效果尤其明显。
+
+### 启动选项中的常用语法
+
+Steam 游戏的启动选项通常都符合 `ENVIRONMENT_VARIABLES command_or_script %command% --arguments` 的模式。
+
+- `%command%` 对应游戏的可执行文件本身，因此除了以下两种情况外，必须在启动选项中出现：
+  - 启动选项为空，或只有`--arguments`的参数（比如`--wine-canonical-hole=SKIP_VOLATILE_CHECK`）；
+  - 命令或脚本本身即可启动游戏且不需要经过 Steam。
+- 环境变量应在 `%command%` 之前，但以下三种情况下可以省略：
+  - 在 `~/.config/environment.d` 或其他全局变量的加载位置已经定义的值；
+  - 在 Bazzite Portal 中已经定义的值（本质上就是上一条）；
+  - `%command%` 前的命令或脚本会设置的环境变量。
+- `%command%` 之后的参数被视为提供给游戏可执行文件本身。
+
+**示例:**
+```bash
+PROTON_LOG=1 %command%                    # 启用 Proton 的日志
+STEAMDECK=0 %command%                     # 禁用 Steam Deck 相关调整
+PROTON_ENABLE_NGX_UPDATER=1 %command%     # 允许 Proton 覆盖 DLSS 组件以升级
+%command% --in-process-gpu                # 在一些 Unity 游戏中修复启动时白屏的问题，%command% 可以省略
+scb %command%                             # 用 ScopeBuddy （Gamescope 的辅助程序）启动游戏
+```
+
+### Proton 启动选项
+<small>_觉得很眼熟吗？本章（的英文版）直接来自于 [Proton-CachyOS Wiki](https://wiki.cachyos.org/configuration/gaming/#environment-variables)。<del>你可能就是下一个！</del>_</small>
+
+自定义 Proton 版本的往往自带比较激进的默认配置。具体情况请参考各个项目的官方文档。
+
+- Proton-CachyOS
+  - [Readme](https://github.com/CachyOS/proton-cachyos/blob/cachyos_main/README.md#proton-cachyos-config-options)
+  - [Changelogs](https://github.com/CachyOS/proton-cachyos/blob/cachyos_main/CHANGELOG.md)
+- Proton-EM
+  - [Readme](https://github.com/Etaash-mathamsetty/Proton/blob/em-11-hdr/README.md)
+  - [EM-ADDITIONS](https://github.com/Etaash-mathamsetty/Proton/blob/em-10-hdrtest/docs/EM-ADDITIONS.md)
+  - [FSR4](https://github.com/Etaash-mathamsetty/Proton/blob/em-10-hdrtest/docs/FSR4.md)
+  - [Wine-Wayland](https://github.com/Etaash-mathamsetty/Proton/blob/em-10-hdrtest/docs/CHANGES.md)
+
+### Bazzite 提供的实用工具
+
+Bazzite 针对一些常用的启动选项提供了一些捷径。
+
+#### Steam Deck 模式开关
+
+- **`sd0 %command%`** - `SteamDeck=0 %command%` 的简写形式
+  - 关闭一些游戏针对 Steam Deck 的特殊配置
+  - 用例：Expedition 33 在不进行该设置时默认采用面向 Steam Deck 的（比极低还低的）画质预设，并禁用绝大多数画质选项。
+
+#### NVIDIA (dlss-swapper)
+
+- **`dlss-swapper %command%`** - 用 NGX Updater 自动应用最新的 DLSS 配置
+  - 本质为`PROTON_ENABLE_NGX_UPDATER=1 DXVK_NVAPI_DRS_SETTINGS=NGX_DLSS_SR_OVERRIDE=on,NGX_DLSS_RR_OVERRIDE=on,NGX_DLSS_FG_OVERRIDE=on,NGX_DLSS_SR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest,NGX_DLSS_RR_OVERRIDE_RENDER_PRESET_SELECTION=render_preset_latest %command%`的简写
+- **`dlss-swapper-dll %command%`** - 同上，但跳过 NGX Updater
+
+!!! info
+
+    DLSS 并非一刀切的越新越好，因此 Bazzite 有意保留了这套配置，而非完全依赖较新的 `PROTON_DLSS_UPGRADE=1`（此功能在 Bazzite Portal 上亦有记载）。
+
+#### 如何设置启动选项
+
+1. 在 Steam library 内右键选择一个游戏
+2. 选择**属性**
+3. In the General tab, find **Launch Options** field
+4. 输入你需要的启动选项
+
+![Launch Options view|833x594, 75%](../img/Steam_Launch_Options.png)
+
+## 帧率限制相关问题
+
+游戏模式（gamescope）支持多种帧率限制的方式，但根据游戏与硬件配置，并非所有方法都稳定有效。
+
+帧率限制的效果有时并不稳定，尤其是在桌面模式下。
+
+The tables below show the behavior of different framerate limiting methods.
+
+=== "Steam Game Mode (Steam Gaming Mode Session)"
+
+    | 方法 | 如何设置 | 是否需要游戏内启用垂直同步？ | 不重启游戏能否生效？ | 对延迟的影响 | 是否推荐 | 备注 |
+    |---|---|---|---|---|---|---|
+    | **Gamescope FPS limiter** | Use **Quick Access Menu → Performance → Framerate Limit** | No | Yes | Generally Worse | **Preferred** | Automatically enables v-sync at driver-level whenever the framerate cap is enabled. Additional latency will be introduced. |
+    | **MangoAPP (embedded)** | - | - | - | - | – | N/A - doesn't work at all. |
+    | **MangoHUD (external)** | **Launch Options:** `MANGOHUD=1 %command%` | No | Yes | Generally Worse | – | Set `fps_limit=0,{fps}...` (`0`=no cap) in `MangoHud.conf` or use [MangoJuice](https://flathub.org/en/apps/io.github.radiolamp.mangojuice). |
+    | **DXVK/VKD3D runtime frame limiter** | **DXVK(D3D8/9/10/11):** `DXVK_FRAME_RATE={fps} %command%`<br>**VKD3D(D3D12):** `VKD3D_FRAME_RATE={fps} %command%` | No | No | Generally Better | – | Applies only to DXVK/VKD3D titles (no effect on native OpenGL or Vulkan games). |
+
+=== "桌面模式 （GNOME/KDE Plasma 桌面会话）"
+
+    | 方法 | 如何设置 | 是否需要游戏内启用垂直同步？ | 不重启游戏能否生效？ | 对延迟的影响 | 是否推荐 | 备注 |
+    |---|---|---|---|---|---|---|
+    | **Gamescope 自带帧率限制** | **游戏启动选项**：`gamescope -r {fps} -- %command%`或`--framerate-limit {fps}` | 是 | 是* | 相对较差 | – | *`gamescopectl debug_set_fps_limit {fps}`可以不重启游戏应用新的限制值。 |
+    | **MangoAPP（Gamescope 集成）** | **游戏启动选项**：`gamescope --mangoapp -- %command%` | 是 | 是 | 相对较差 | – | 限制有时无法生效。配置方式参考 MangoHUD。 |
+    | **MangoHUD（外部安装）** | **游戏启动选项**：`MANGOHUD=1 %command%` | 否 | 是 | 相对较好 | **推荐** | 限制通常稳定生效。在`MangoHud.conf` 中进行配置（`fps_limit=0,{fps}...`，0对应无限制），或使用 [MangoJuice](https://flathub.org/en/apps/io.github.radiolamp.mangojuice)。 |
+    | **DXVK/VKD3D 自带帧率限制** | **DXVK(D3D8/9/10/11):** `DXVK_FRAME_RATE={fps} %command%`<br>**VKD3D(D3D12):** `VKD3D_FRAME_RATE={fps} %command%` | 否 | 否 | 相对较好 | – | 只适用于需要转译的 DirectX 游戏，对本身是 OpenGL 或 Vulkan 的游戏无效。 |
+
+如果限制配置没有生效，以下两步可能会有帮助：
+
+- 禁用帧率自适应同步（Adaptive sync）和可变刷新率（VRR）；如果你的 Gamescope 启动参数中有`--adaptive-sync`，尝试移除。
+- 在游戏内启动垂直同步（Vsync）。
+
+!!! Note
+
+    游戏内的延迟往往是个很复杂的问题，不同配置的情况可能天差地别。几乎不可能有一套解决一切问题的“完美”参数，而是需要用户根据自己的实际需求不断进行打磨与测试。
+    
+    除此之外，上游的 DXVK 和 VKD3D 自 3.0 版本起已经不再支持直接通过 `DXVK_FRAME_RATE` 环境变量来限制帧率，而是由 Proton 按自身需求进行调整。Valve 官方的 Proton 使用的是上游的 DXVK/VKD3D，因此如果你仍然需要在 DXVK/VKD3D 层面上限制帧率，则需要[特定的 Proton 版本](#proton-launch-options) 或用自定义版本的 DXVK 直接配合 Wine 运行，比如 [DXVK Low-Latency](https://github.com/netborg-afps/dxvk-low-latency).
+    
+    Proton-CachyOS 自带 DXVK-LL，因此支持 `PROTON_DXVK_LOWLATENCY=1`，是一个不错的出发点。
+
+## 使用 ScopeBuddy 进一步调整启动选项
+
+[**ScopeBuddy** 的文档](../Advanced/scopebuddy.md) 将会介绍在 Gamescope 上更进一步的启动选项管理。

--- a/src/Gaming/launch-options-env-variables.zh_CN.md
+++ b/src/Gaming/launch-options-env-variables.zh_CN.md
@@ -95,7 +95,7 @@ Bazzite 针对一些常用的启动选项提供了一些捷径。
 
     | 方法 | 如何设置 | 是否需要游戏内启用垂直同步？ | 不重启游戏能否生效？ | 对延迟的影响 | 是否推荐 | 备注 |
     |---|---|---|---|---|---|---|
-    | **Gamescope 自带帧率限制** | Use **Quick Access Menu → Performance → Framerate Limit** | 否 | 是 | 相对较差 | **Preferred** | Automatically enables v-sync at driver-level whenever the framerate cap is enabled. Additional latency will be introduced. |
+    | **Gamescope 自带帧率限制** | Use **Quick Access Menu → Performance → Framerate Limit** | 否 | 是 | 相对较差 | **推荐** | Automatically enables v-sync at driver-level whenever the framerate cap is enabled. Additional latency will be introduced. |
     | **MangoAPP（Gamescope 集成）** | - | - | - | - | – | 默认会话无法添加需要的参数，因此不可用。 |
     | **MangoHUD（外部安装）** | **游戏启动选项**：`MANGOHUD=1 %command%` | 否 | 是 | 相对较差 | – | 在`MangoHud.conf` 中进行配置（`fps_limit=0,{fps}...`，0对应无限制），或使用 [MangoJuice](https://flathub.org/en/apps/io.github.radiolamp.mangojuice)。 |
     | **DXVK/VKD3D runtime frame limiter** | **DXVK(D3D8/9/10/11):** `DXVK_FRAME_RATE={fps} %command%`<br>**VKD3D(D3D12):** `VKD3D_FRAME_RATE={fps} %command%` | No | No | Generally Better | – | Applies only to DXVK/VKD3D titles (no effect on native OpenGL or Vulkan games). |

--- a/src/Gaming/launch-options-env-variables.zh_CN.md
+++ b/src/Gaming/launch-options-env-variables.zh_CN.md
@@ -95,7 +95,7 @@ Bazzite 针对一些常用的启动选项提供了一些捷径。
 
     | 方法 | 如何设置 | 是否需要游戏内启用垂直同步？ | 不重启游戏能否生效？ | 对延迟的影响 | 是否推荐 | 备注 |
     |---|---|---|---|---|---|---|
-    | **Gamescope 自带帧率限制** | Use **Quick Access Menu → Performance → Framerate Limit** | No | Yes | Generally Worse | **Preferred** | Automatically enables v-sync at driver-level whenever the framerate cap is enabled. Additional latency will be introduced. |
+    | **Gamescope 自带帧率限制** | Use **Quick Access Menu → Performance → Framerate Limit** | 否 | 是 | 相对较差 | **Preferred** | Automatically enables v-sync at driver-level whenever the framerate cap is enabled. Additional latency will be introduced. |
     | **MangoAPP（Gamescope 集成）** | - | - | - | - | – | 默认会话无法添加需要的参数，因此不可用。 |
     | **MangoHUD（外部安装）** | **游戏启动选项**：`MANGOHUD=1 %command%` | 否 | 是 | 相对较差 | – | 在`MangoHud.conf` 中进行配置（`fps_limit=0,{fps}...`，0对应无限制），或使用 [MangoJuice](https://flathub.org/en/apps/io.github.radiolamp.mangojuice)。 |
     | **DXVK/VKD3D runtime frame limiter** | **DXVK(D3D8/9/10/11):** `DXVK_FRAME_RATE={fps} %command%`<br>**VKD3D(D3D12):** `VKD3D_FRAME_RATE={fps} %command%` | No | No | Generally Better | – | Applies only to DXVK/VKD3D titles (no effect on native OpenGL or Vulkan games). |

--- a/src/General/FAQ.zh_CN.md
+++ b/src/General/FAQ.zh_CN.md
@@ -1,0 +1,205 @@
+---
+title: 常见问题
+---
+
+# 常见问题（FAQ）
+
+## Bazzite 面向的用户是？
+
+如果你想要符合以下任意要求的操作系统，那么 Bazzite 应该会很合适：
+
+- 一个类似于 SteamOS，和其他 Linux 发行版相比维护成本较低的可用于桌面的操作系统；
+- 更适合沙发上<del>葛优躺时</del>用手柄控制的前端用户界面；
+- 在原装 Windows 的掌机设备上类似于 SteamOS 的操作体验，但 SteamOS 目前暂时不支持你的设备；
+- 对已经运行 SteamOS 的掌机设备（比如 Steam Deck 或 Lenovo Legion Go S SteamOS Edition），想要更新版的软件包但也想保证系统组件的稳定性。
+
+## 我应该选择哪个版本？
+
+[Bazzite 官网](https://bazzite.gg/#image-picker) 提供了一个选择器，能够根据你的硬件、想要的桌面环境、是否需要 Steam 游戏模式（如果硬件支持）这几个问题决定最合适的版本。
+
+Bazzite 有很多种镜像，但总体上来讲可以分成三类：
+
+- **桌面版**: 不包含 Steam 游戏模式，但仍然预装一些游戏相关的软件包。每天自动更新。
+- **掌机版**: 开机自动启动 Steam 游戏模式，类似于 SteamOS。更适合手柄控制。
+- **开发者版**: 面向软件开发的 Bazzite 镜像。
+
+### 1. 桌面版
+
+**该版本不包含 Steam 游戏模式！**
+
+灵感来源于 SteamOS 的桌面模式和 ChromeOS 的低维护形式，但是面向绝大多数的桌面和笔记本设备。基于 Fedora Atomic （Kinoite/Silverblue），将 Steam 和其他游戏相关的实用工具集成进系统镜像。兼容绝大多数较新硬件配置（只要 Linux 上游支持）。预配置的 [Flathub](https://flathub.org/) 保证和 SteamOS 能够使用的应用一致。应用程序和系统自动定时更新，每次重启时自动应用。
+
+### [2. 掌机版（Bazzite-Deck）](../Handheld_and_HTPC_edition/Steam_Gaming_Mode.md)
+
+预装了**Steam 游戏模式**，并在兼容的硬件上支持所有相关功能。该版本默认开机自动启动到 Steam 游戏模式，因此更适合掌机设备和手柄优先的配置。同样自带 GNOME 或 KDE Plasma 的桌面模式。更新不会自动安装，需要手动进行后重启以应用。
+
+### [3. 开发者版（Bazzite-DX）](https://dev.bazzite.gg/)
+
+专精软件开发相关优化的 Bazzite 版本。不提供 ISO，而是通过从已有的镜像切换来进行安装。
+
+#### Bazzite 镜像对比表
+
+!!! note
+
+    这个表格不一定对应所有当前支持的 Bazzite 镜像。
+
+在终端输入以下命令以确定当前运行的 Bazzite 镜像。
+
+```
+rpm-ostree status
+```
+
+!!! important
+
+    Bazzite 镜像一般都应该以`ostree-image-signed:docker://ghcr.io/ublue-os/`开头。
+    <sub> 之后的名称是实际的 Bazzite 版本，对应以下表格。</sub>
+
+| **镜像名称**              | 桌面环境 | Steam 游戏模式 | 面向硬件                                 | 版本       |
+| --------------------------- | ------------------- | ----------------- | ------------------------- | ---------- |
+| `bazzite`                   | KDE Plasma          | 否                | AMD 或 Intel 显卡          | 桌面版      |
+| `bazzite-nvidia`            | KDE Plasma          | 否                | NVIDIA 显卡                | 桌面版      |
+| `bazzite-nvidia-open`       | KDE Plasma          | 否                | 较新的 NVIDIA 显卡          | 桌面版      |
+| `bazzite-gnome`             | GNOME               | 否                | AMD 或 Intel 显卡          | 桌面版      |
+| `bazzite-gnome-nvidia`      | GNOME               | 否                | NVIDIA 显卡                | 桌面版      |
+| `bazzite-gnome-nvidia-open` | GNOME               | 否                | 较新的 NVIDIA 显卡          | 桌面版      |
+| `bazzite-deck`              | KDE Plasma          | 是                | AMD 或 Intel Arc 显卡      | 掌机版      |
+| `bazzite-deck-nvidia`       | KDE Plasma          | 是                | 较新的 NVIDIA 显卡          | 掌机版      |
+| `bazzite-deck-nvidia-gnome` | GNOME               | 是                | 较新的 NVIDIA 显卡          | 掌机版      |
+| `bazzite-deck-gnome`        | GNOME               | 是                | AMD 或 Intel Arc 显卡      | 掌机版      |
+
+## 如果 SteamOS 基于 Arch Linux，为什么要换成 Fedora Atomic？
+
+虽然 Arch Linux 为滚动发布，但 SteamOS 的更新基本独立，因此频率更低。Bazzite 基本遵循 Fedora 的发布频率，因此往往能够比 SteamOS 更早获取驱动程序和内核版本的更新。Fedora Atomic 和 Universal Blue 目前的实现使得同一套更新能够快速的在一台镜像的多个变体上应用，这与传统意义上的衍生发行版有所不同。**Bazzite 致力于保证安装好的系统开箱即用，可以快速上手游戏。**
+
+### 用 Fedora Atomic 作为基础镜像有什么好处？
+
+作为自定义的 Fedora Atomic 桌面镜像，Bazzite 同样采用只读根目录的处理方法，在此基础上通过[可引导容器](https://containers.github.io/bootable/)部署系统，有这样一些好处：
+
+- 完全无法启动的概率更低；
+- 回滚系统更新或锁定当前已知正常运行的系统版本，且不影响用户数据；
+- 与 Fedora 基本同步的稳定大版本发布；
+- 更适合容器化的程序部署，保证程序不会干扰系统运行。
+
+> [**Universal Blue 的主页**](https://universal-blue.org) 提供了关于整个项目的更多信息。
+
+## AMD 和 Intel 的显卡驱动有预先安装吗？
+
+**是**。绝大多数硬件所需的驱动组件都直接集成在上游 Linux 内核中，并随系统一起更新。Bazzite 不支持手动安装不同的驱动或 Linux 内核版本，但反过来说，每个发布的 Bazzite 版本对应的版本组合都经过测试确定能够有效运作。
+
+### NVIDIA 的显卡驱动有预先安装吗？
+
+**在`-nvidia`和`-nvidia-open`版的镜像上是。**它们也同样和系统其他组件一起更新，不支持手动安装。
+
+- `-nvidia`的旧镜像支持 Pascal、Maxwell 和 Volta 架构（GTX 900, GTX 1000, Nvidia Titan V, GTX 750 (TI) and GTX 745）；
+- 更新的`-nvidia-open`镜像支持 Turing 及之后的所有架构（GTX 16 系和 RTX 全系）。
+
+!!! notice "如果运行程序时碰到 NVIDIA 相关的问题，请确定你[运行的镜像](./#bazzite-image-chart-example)正确，且 [Flatpak 相关的运行时组件为最新](/General/issues_and_resolutions/#flatpak-apps-have-no-hardware-acceleration-on-nvidia)。"
+
+#### 更老的 NVIDIA 显卡呢？
+
+由于 NVIDIA 上游的驱动已经**不再支持** Kepler 架构及更老的显卡（绝大多数 GTX 700 系或更早的显卡），Bazzite 也无法为其提供支持。
+
+-   使用开源的`nouveau`驱动可以运行 Bazzite；
+    -   但`nouveau`驱动无法调用显卡的闭源固件（如 GSP），因此无法调节主频等配置，在性能和稳定性上也难免弱于官方驱动；
+-   Bazzite **无法支持**手动安装的 NVIDIA 专有驱动；
+-   如果你必须使用官方驱动，则必须选择其他的发行版。Bazzite 面临的限制也同样影响所有 Fedora 系的发行版。
+
+!!! info
+
+    NVIDIA 驱动在 495 及之后的版本中才支持 Wayland。由于 Kepler 架构及更老的显卡的驱动版本只到 470，且 Bazzite 不支持纯 X11 的显示协议，这意味着这些显卡很难在 Bazzite 上正常工作。这种情况下 Linux Mint 或 Debian 等其他发行版可能更为适合。
+
+### 如果我更换了硬件，需要怎么处理？
+
+绝大多数情况下不需要软件方面的任何额外操作。不过，如果是新装或移除了 NVIDIA 显卡，可能需要[切换镜像](../Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/brh.md)以确保所使用的显卡驱动对应新的显卡配置。
+
+## 手动运行系统更新时报错`error: System transaction in progress`
+
+![](/../img/system-transaction-in-progress.png)
+
+[桌面版](#1-desktop-edition)镜像默认在后台自动更新。如果更新正在进行时你触发了手动更新，则会出现这个警告。通常只需等待一小会，让自动更新自己完成即可。
+
+## Windows 游戏提示显卡驱动需要更新，该怎么做？
+
+![](/../img/gpu_driver_warning.png)
+Windows 游戏往往难以正确判断 Linux 上的驱动程序版本是否为最新。
+
+-   Windows 和 Linux 的驱动版本号往往不同，因此 Windows 游戏可能会提示版本号相关的错误；
+-   **这类错误通常可以忽略；**
+-   [更多信息请参考这一部分。](#are-amd-and-intel-graphics-card-drivers-pre-installed)
+
+## Bazzite 支持 CSM/传统 BIOS 启动吗？
+
+不支持。安装器检测到 CSM 启动时应该会输出警告并提供关闭 CSM 的相关步骤：![CSM](../img/csm.webp)
+
+## 能使用 AFMF 或 FSR-FG 一类的帧生成技术吗？
+
+**仅限支持 FSR 3.1 或更高的游戏。**简单来说：
+
+-   AFMF 一类的驱动层面的帧生成在 Linux 使用的开源驱动下不可用；
+-   特定游戏可能会有专门的模组或 [Decky 插件](https://github.com/xXJSONDeruloXx/Decky-Framegen)提供类似功能；
+-   `Proton-CachyOS 11.0-20260702` 及其衍生版本会将支持 FSR 3.1+ 的游戏自动升级到 FSR4.1.1。具体信息请参考[Proton-CachyOS 的 GitHub 发布页](https://github.com/CachyOS/proton-cachyos/releases/tag/cachyos-11.0-20260702-slr)。对于 RDNA3 显卡，**Bazzite Portal** 也提供 FSR-MLFG 的快捷开关；
+* 如果你在 Steam 上拥有 [Lossless Scaling](https://store.steampowered.com/app/993090/Lossless_Scaling/)，可以借助 **Bazzite Portal** 的快捷命令配置 LSFG 的 Vulkan 层。
+
+## 能搞 GRUB 美化吗？
+
+!!! note
+    
+    Bazzite 默认启动时隐藏 GRUB 菜单，除非双启动或者连续启动失败。
+    
+由于 OSTree 系统需要的一些特定的 GRUB 配置，Bazzite 无法支持 GRUB 自定义。如果遇到问题，我们建议删除所有 GRUB 自定义美化后再次尝试。
+
+## 如何修改我的主机名称？
+
+!!! note
+
+    由于 Distrobox 容器的相关限制，主机名不能超过 **20 个字符**。
+
+在终端输入以下命令：
+
+```
+hostnamectl hostname <hostname>
+```
+
+用你想要的主机名替代`<hostname>`。
+## 我安装/更新了 Windows 之后 Bazzite 无法启动 { id="windows-bootloader-override" }
+
+绝大多数情况下是 Windows 把 Bazzite 的引导组件当减速带肘了。Bazzite 的安装镜像提供了相关的修复工具，只需重新从 U 盘启动 ISO 并选择 **Bazzite Bootloader Restoration Tool** 即可。
+
+## 我能不重装更换桌面环境吗？
+<sub>（在目前 Bazzite 支持的配置下，也就是通过切换镜像进行 GNOME 和 KDE Plasma 之间的转换）</sub>
+
+理论可以但**不推荐**，因为 GNOME 和 KDE Plasma 对一些共用的用户级配置文件的处理方式并不完全兼容，这会导致更换桌面环境后一些用户界面要素出现显示问题。[Mending Wall](https://flathub.org/en/apps/org.indii.mendingwall) 这一实用工具可以帮助处理配置文件的一些变化，但 Bazzite 无法为其提供支持。
+
+最稳妥的更换桌面环境的方法仍然是手动备份用户文件之后完全重装。
+
+## 能使用其他桌面环境或窗口管理器吗？
+
+以 Bazzite 为基础[自制镜像](/Advanced/creating_custom_image.md)，即可配置你所想要的桌面环境或窗口管理器。
+
+## GRUB 菜单中的`:0`和`:1`是什么？
+
+`:0`和`:1`是回滚系统的相关机制。每次更新完成后，更新前的版本会成为`：1`，而新版本会成为`:0`。
+
+- `:0` = 当前部署，通常是最新版本；
+- `:1` = 上一个部署。
+
+如果有已锁定的部署版本，则可能会进一步出现`:2`甚至`:3`等条目。如果空间足够，完全可以锁定更多版本。
+
+## Bazzite 这个名字是怎么来的？
+
+[Fedora Linux 的 Atomic 系列版本](https://fedoraproject.org/atomic-desktops/) 一开始是以[矿物质](https://fedoraproject.org/kinoite/)命名的。Bazzite 是一种强度较高、密度较小的矿物，而且是[蓝色](https://universal-blue.org/)的！
+
+## 我想要一款不主要面向游戏的 Bazzite
+
+Universal Blue 旗下还有两个和 Bazzite 同源但不主要面向游戏的系统。它们都仍然可以运行游戏，但和 Bazzite 相比没有那么多游戏特化的预装软件或系统优化。三个项目也在很大程度上共享开发资源和团队。
+
+- [**Aurora**](https://getaurora.dev/) 对应 **KDE Plasma** 桌面环境；
+- [**Bluefin**](https://projectbluefin.io/) 对应 **GNOME** 桌面环境。
+
+## 文档里没有提到的问题？
+
+!!! note
+
+    在提出新问题之前，建议先根据问题相关的关键词再次搜索 Bazzite 文档。
+
+欢迎在[Bazzite 的 GitHub 仓库](https://github.com/ublue-os/bazzite/issues)中氵 issue。不过需要注意的是，有些问题往往不在 Bazzite 团队的能力范围内，比如 NVIDIA 驱动问题、特定游戏的兼容性，或一些整个桌面级 Linux 的大环境问题。

--- a/src/General/FAQ.zh_CN.md
+++ b/src/General/FAQ.zh_CN.md
@@ -202,4 +202,4 @@ Universal Blue 旗下还有两个和 Bazzite 同源但不主要面向游戏的�
 
     在提出新问题之前，建议先根据问题相关的关键词再次搜索 Bazzite 文档。
 
-欢迎在[Bazzite 的 GitHub 仓库](https://github.com/ublue-os/bazzite/issues)中氵 issue。不过需要注意的是，有些问题往往不在 Bazzite 团队的能力范围内，比如 NVIDIA 驱动问题、特定游戏的兼容性，或一些整个桌面级 Linux 的大环境问题。
+欢迎在 [Bazzite 的 GitHub 仓库](https://github.com/ublue-os/bazzite/issues)中氵 issue。不过需要注意的是，有些问题往往不在 Bazzite 团队的能力范围内，比如 NVIDIA 驱动问题、特定游戏的兼容性，或一些整个桌面级 Linux 都有的大环境问题。

--- a/src/General/Installation_Guide/secure_boot.zh_CN.md
+++ b/src/General/Installation_Guide/secure_boot.zh_CN.md
@@ -1,0 +1,90 @@
+---
+title: 安全启动指南
+tags:
+  -  QR
+search:
+  exclude: true
+---
+
+# 安全启动指南
+
+## Bazzite 支持安全启动
+
+!!! note
+
+    如果你的设备不支持安全启动或你不打算启用安全启动，则直接选择`Continue boot`。
+
+!!! important
+
+    安全启动的管理界面锁定为英语的 QWERTY 键盘布局，无关你键盘的硬件配置。如果你使用 AZERTY 等键位不同的布局，需注意对应关系。
+
+Bazzite 支持安全启动（Secure Boot），但需要导入 Universal Blue 配置的密钥，否则之后的启动会失败。
+
+## 安全启动重要提醒
+
+- 出于安全考虑，输入密码时不会在屏幕上有任何反馈，包括星号。
+- 如果禁用了安全启动之后进行 BIOS 更新，则安全启动可能会自行启用。此时必须走**方法 B** 来修复问题。
+- Steam Deck 默认不启用安全启动，也不自带安全启动需要的密钥，因此不建议在 Steam Deck 上启用安全启动。
+
+## 错误信息（**密钥没有正确导入**时）
+
+```
+error: ../../grub-core/kern/efi/sb.c:182:bad shim signature.
+error: ../../grub-core/loader/1389/efi/linux.c:256:you need to load the kernel first.
+
+Press any key to continue...
+```
+
+如果碰到这一情况，请按**方法 B** 进行修复。
+
+### **方法 A** - 安装时配置
+
+![Secure Boot 管理: Continue boot / Enroll MOK / Enroll key from disk / Enroll hash from disk](../../img/Secure_Boot.png 'Secure Boot')
+
+!!! note
+
+    如果你在安装时没有启用安全启动但之后启用，则在下一次系统启动时也会进入该界面。
+
+退出 Bazzite 的安装程序之后，应该会出现一个蓝色的屏幕，提供导入密钥的选项。
+
+如果你启用了安全启动，则选择`Enroll MOK`。如果提示输入密码，则输入：
+
+```command
+universalblue
+```
+
+如果你没有启用安全启动或硬件不支持，则选择`Continue boot`。
+
+## **方法 B** - 安装后配置
+
+该方法需要**在 BIOS 中禁用安全启动**，**密钥导入完成后**可以重新启用。
+
+在已经安装完成的 Bazzite 系统下，运行：
+
+```
+ujust enroll-secure-boot-key
+```
+
+如果要求输入密码，则输入：
+
+```command
+universalblue
+```
+
+**现在可以在 BIOS 下重新启用安全启动。**
+如果硬件支持，用以下命令直接重新启动到 BIOS 菜单：
+
+```command
+ujust bios
+```
+## 重新启动并完成密钥导入
+
+重新启动后，应该同样进入蓝色界面：
+
+1.  选择 **Enroll MOK**.
+2.  如果要求输入密码，则输入：
+    ```command
+    universalblue
+    ```
+
+再次重启之后，安全启动应该就能正常运作。

--- a/src/General/Installation_Guide/troubleshoot_guide.md
+++ b/src/General/Installation_Guide/troubleshoot_guide.md
@@ -120,6 +120,24 @@ Here are some possible solutions on how you can address it:
 
 ---
 
+## Storage is not showing up in the installer
+
+This happens when your storage is configured as an Intel RAID Array. Non-Enterprise versions of Linux do not ship the necessary drivers to support Intel RST, so the storage cannot be found. 
+
+Solution: You need to disable Intel RAID in the BIOS. 
+
+The setting is usually called either: 
+
+- VMD
+- RST
+- Rapid Storage Tech(nology)
+- Storage mode: AHCI
+!!! warning "Dissolving the RAID will cause any existing Windows installations to break. If you would like to dualboot with Windows, you need to follow these instructions before you turn off RAID https://support.thinkcritical.com/kb/articles/switch-windows-10-from-raid-ide-to-ahci"
+
+!!! note "In some BIOS implementations, disabling RAID does not remove existing RAID Arrays. In this case, you need to manually remove the leftover RAID Array to successfully install Bazzite. Please consult your manufacturer manual on how to do this."
+
+---
+
 ## Alternative Installation Method
 
 !!! note

--- a/src/General/SteamOS_Comparison.zh_CN.md
+++ b/src/General/SteamOS_Comparison.zh_CN.md
@@ -1,0 +1,54 @@
+---
+title: Bazzite 和 SteamOS
+---
+
+# Bazzite 和 SteamOS
+
+## SteamOS 是什么？
+
+**SteamOS** 是 Valve 维护的，最初面向 Steam Deck 的操作系统。SteamOS 通过游戏模式操作 Steam 客户端，并包含简化版的 **KDE Plasma** 桌面环境，允许用户进行一些常见于其他 Linux 系统的操作，但在完全体的桌面环境下可能会显得操作受限。
+
+## Bazzite 是什么？
+
+Bazzite 是一款社区维护的，游戏优先的 Linux 操作系统，自带最新的 Linux 驱动和面向不同需求的变种镜像：**桌面版 (Bazzite)**、**掌机版（Bazzite-Deck）**和 **开发者版（Bazzite-DX）**。Bazzite 基于 [**Fedora Linux**](https://fedoraproject.org/)，并采用[**原子化的更新体系**](https://github.com/bootc-dev/bootc)，保证更新出现问题时总能回滚到上一个确定正常的版本。
+
+除此之外，Bazzite 也更加面向日常使用，同时兼顾**游戏**、**多媒体**和**软件开发**等方面。更频繁的驱动更新也保证 Bazzite 在 Linux 中的设备支持足够靠前，不论是 **AMD**、（较新的）**NVIDIA** 还是 **Intel** 显卡。Bazzite 还支持 **Lenovo**、**ASUS**、**Ayn**、**GPD** 和 **OneXPlayer** 等品牌的掌机设备。
+
+### 和 SteamOS 相比，Bazzite 提供的优化点
+
+-   支持和 **Windows** 系统共存的**双启动**环境；
+-   兼容**更多的** x86 掌机：Lenovo Legion Go/S、ASUS ROG Ally/X、OneXPlayer F1/G1/X1 及变种、GPD Win 4/Mini/Max、Ayn Loki、MSI Claw 1st Gen AI7+/8+、Zotac Zone、Ayaneo Air/Geek/Next、Steam Deck LCD/OLED；
+-   支持桌面级显卡和风扇的调节；
+-   **超 雄 更 新**
+  -   **每次更新前的版本**都可以通过 GRUB 直接回滚；
+  -   掌机版下，如果连续三次启动失败，会自动执行回滚；
+  -   **最近 90 天内发布的所有版本都在线上保留**，一条命令即可在线回滚到特定版本；
+-   **Linux 内核**、**显卡驱动**和 [**Gamescope**](https://github.com/ValveSoftware/gamescope) 合成器等软件都有活跃更新；
+-   更及时更新的 **KDE Plasma** 和 **GNOME** 桌面环境；
+-   自带**游戏相关的实用软件**, 包括**Lutris、ScopeBuddy GUI、ProtonUp-QT/ProtonPlus、Protontricks**等；
+-   **GNOME** 桌面环境作为 KDE Plasma 的替代；
+-   通过 Flatpak 支持的**虚拟化**和 **GPU 穿透**；
+-   通过 [Waydroid](/Installing_and_Managing_Software/Waydroid_Setup_Guide.md) 安装 **Android 程序**；
+-   多种方式配置 [**Sunshine**](/Advanced/sunshine/) 的脚本，让游戏串流更方便；
+-   **[Bazzite Portal](/Installing_and_Managing_Software/Bazzite_Portal.md)** 和 [`ujust`](/Installing_and_Managing_Software/ujust.md) 快捷脚本提供方便的系统设置或常用软件的配置；
+-   默认使用 **BTRFS** 文件系统，支持自动**去重**和**压缩**（SteamOS 使用的是 **Ext4**），并支持**内部存储**和 **SD 卡**的**自动挂载**。
+
+### 日常使用
+
+-   系统组件更新更加频繁；
+-   桌面模式使用 Wayland，保证在高分辨率显示配置下显示比例仍然正确；
+-   绝大多数自带软件包按 Fedora 的更新周期运作，除非测试中发现问题（此时可能会延后更新或提前修复）。
+
+### 开发者
+
+-   通过 [Distrobox](https://distrobox.it) 使用其他发行版的包管理器和软件仓库；
+-   预安装了 [Homebrew](https://brew.sh/) 用于管理用户级的命令行程序；
+-   通过 [Layering](/Installing_and_Managing_Software/rpm-ostree.md) 将 Fedora 软件包加入系统树，在系统更新中也能保留；
+-   更多信息请参考 [Bazzite DX 官网](https://dev.bazzite.gg)。
+
+### 安全性提升
+
+Bazzite 支持 LUKS 加密、安全启动，和基于 TPM 的自动解锁。除此之外，Bazzite 默认启用并预先配置了 [SELinux (安全增强的 Linux)](https://www.redhat.com/en/topics/linux/what-is-selinux) 。
+
+安全启动在和 Windows 双启动的环境下同样有用，尤其是考虑到有些 Windows 上的反作弊组件要求启用安全启动。
+>请参考[**安全启动相关指南**](/General/Installation_Guide/secure_boot.md)。

--- a/src/General/issues_and_resolutions.md
+++ b/src/General/issues_and_resolutions.md
@@ -4,48 +4,80 @@ title: Common Issues & Resolutions
 
 # Common Issues & Resolution
 
-## Steam Big Picture Mode is slow
+## Index
 
-When you select **Steam Menu → View → Big Picture** the user interface runs sluggishly, while the games that run through the interface works smoothly.
-
-If you encounter this issue, close Steam completely and start Steam using the **Steam Big Picture Mode** menu shortcut. Also make sure that **Steam Settings → Interface → Enable GPU accelerated rendering in web views (requires restart)** is enabled in the Steam settings.
-
->**Note**: This fix also fixes the performance issues in Steam Gaming Mode on Nvidia GPUs, however, this comes with a drawback that the Steam menu and side menu sometimes do not render properly.
-
----
-
-## Audio is soft on ASUS ROG Ally hardware
-
-There are two audio devices that appear on the Rog Ally:
-
--   **Family 17h/19h/1ah HD Audio Controller**
--   **ROG Ally**
-
-Both affect each other's audio volume, so they must be at the same volume level.
+- [Display and Graphics](#1-display-and-graphics)
+- [Controllers and Gaming Inputs](#2-controllers-and-gaming-inputs)
+- [Network and Wi-Fi](#3-network-and-wi-fi)
+- [Desktop Environment and System Configuration](#4-desktop-environment-and-system-configuration)
+- [Application and Software](#5-application-and-software)
 
 ---
 
-## Disable Special Character Pop-Up on KDE Plasma
+## 1. Display and Graphics
 
-KDE Plasma 6.7 added the Plasma Keyboard feature, which shows an on-screen pop-up when certain keys are held for a period.
+### Cursor is Flickering or has Disappeared
 
-You may disable it in **System Settings → Keyboard → On-Screen Keyboard → Show popup when holding a key**.
+This is typically due to bugs in the GPU drivers. You may temporarily disable Hardware Cursors as a workaround.
 
-![Turning off special characters pop-up|1181x1024, 50%](/img/turn-off-special-char-pop-up.png)
+=== "KDE Plasma"
+
+    Add an environment variable with this command:
+
+    ```bash
+    echo "KWIN_FORCE_SW_CURSOR=1" > ~/.config/environment.d/99-kwin-force-sw-cursor.conf
+    ```
+
+=== "GNOME"
+
+    Add an environment variable with this command:
+
+    ```bash
+    echo "MUTTER_DEBUG_DISABLE_HW_CURSORS=1" > ~/.config/environment.d/99-mutter-disable-hw-cursor.conf
+    ```
+
+!!! warning "This fix may negatively affect the battery life of your laptop or handheld."
 
 ---
 
-## Firefox and KeePassXC Does Not Work Together
+### Flatpak Apps have no Hardware Acceleration on Nvidia
 
-This is because KeePassXC(or other password managers installed via Flatpak) is sandboxed and can only be accessed by a non-sandboxed application.
+If you have recently updated Bazzite on a device with an Nvidia GPU, you might notice that Flatpak applications are running poorly and/or have no hardware acceleration, and/or receive a warning about **Nvidia Flatpak Runtime mismatch**.
 
-You may try installing Firefox and KeePassXC via distrobox, though there may be problems regarding hardware acceleration.
+In this case, you should update all Flatpaks in **Bazaar**, or select **Update Nvidia Flatpak Runtime** under **Bazzite Portal** → **Manage Bazzite** if you do not want to update other Flatpaks.
 
-!!! info "Alternatively, you may also try [this guide](https://discourse.flathub.org/t/how-to-run-firefox-and-keepassxc-in-a-flatpak-and-get-the-keepassxc-browser-add-on-to-work/437). Note that Bazzite officially neither maintains nor endorses the aforementioned guide and it is only included for the sake of completeness. Only follow it at **your own risk**. "
+!!! info "Bazzite provides a systemd service that automates this, but you may still need to update it manually in some situations (e.g. No Internet connection on startup). The ideal solution is for upstream Flatpak/Nvidia to improve the way these Runtimes are handled, or to create a package that provides a Flatpak Nvidia driver using system libraries, but those require a lot more work to make possible."
 
 ---
 
-## Gamepads and Handheld Joysticks Don't Work in Desktop Mode
+### HDMI-CEC Does Not Work Consistently
+
+In [Bazzite Portal](/Installing_and_Managing_Software/Bazzite_Portal), select **Troubleshoot → Change CEC mode**:
+
+!!! note "`cecd` is known to interfere with wakeup on HTPC setups that use dongles. Try setting dGPU mode and see if HDMI-CEC behavior is consistent."
+
+*   dGPU mode (Legacy): Use the “legacy” cec-control services using `libcec` and `cec-ctl`, known to work pretty well on HTPCs with things like pulse8 and ugreen adaptors. These adapters are typically used to work around dGPUs not having cec pin 13 wired up. 
+*   Native mode (New): Use Valve's newer `linux-cec`/`cecd` system instead and mask the legacy services.
+
+!!! info "Native mode builds `linux-cec` from Valve's upstream GitLab repo and includes the inputattach CEC units and linuxconsoletools, so Pulse-Eight style adapters can be attached to the kernel CEC subsystem. However, Ugreen HDMI Adapters are known to behave inconsistently when using Native mode."
+
+---
+
+### Nvidia Optimus GPU not Detected on Laptops
+
+If you are running Bazzite on a laptop with an Nvidia Optimus GPU, you might notice that games are running poorly and seem to be running on the integrated GPU.
+
+In this case, use the preinstalled [Cardwire](https://github.com/OpenGamingCollective/cardwire) app to configure your GPU Power Options. You may simply search **cardwire** to open the app.
+
+> Learn more about Cardwire [here](/Advanced/cardwire)!
+
+!!! info "If you are looking for **Advanced Optimus** functions, we regret to tell you that there are currently **no** working way to dynamically MUX displays outside of some very early work on AMD SmartMUX. Changing MUX settings currently **requires** a reboot."
+
+---
+
+## 2. Controllers and Gaming Inputs
+
+### Gamepads and Handheld Joysticks Don't Work in Desktop Mode
 
 Open **Steam Settings → Controller → Non-Game Controller Layouts → Desktop Layout**. Click **Edit** → **Enable Steam Input** and configure how the controller needs to act as keyboard and mouse in Desktop Mode.
 
@@ -55,31 +87,19 @@ Open **Steam Settings → Controller → Non-Game Controller Layouts → Desktop
 
 ---
 
-## Setting Bazzite's Desktop Editions to automatically login
+### Xbox Controller over Bluetooth is Stuck on a Connecting Loop and the Xbox Button Keeps Flashing
 
-=== "KDE Plasma"
+This is because your controller is not on the latest firmware.
 
-    Open **System Settings → Colors and Themes → Login Screen**. On that screen, tick **"Automatically log in"**, select your user and for the session, select **"Plasma"** and don't forget to to click on the **"Apply"** button.
-    
-=== "GNOME"
+The easiest solution here is to connect the controller to a Windows machine. Download the Xbox Accessories app and update the controller to the latest firmware. After that, the controller should connect seamlessly. 
 
-    Open the **Settings application → Users**. Click the **Unlock** button in the top right corner. Then switch on **Automatic Login**.
+A more advanced way is to spin up a Windows VM and passthrough the controller to do the firmware update there.
 
 ---
 
-## HTPC legacy hardware setup
+## 3. Network and Wi-Fi
 
-As Steam Gaming Mode is not supported on some GPUs, the guide below is a way to set up a similar experience using Bazzite's Desktop image.
-
-Enable auto-login and set Steam to automatically launch in Steam's Big Picture Mode for a decent couch gaming experience.
-
-There is a video guide that you can follow for Bazzite's GNOME Desktop image using a Nvidia GPU (before Nvidia hardware could run Steam Gaming Mode, but same idea):
-
-https://www.youtube.com/watch?v=F9l-RQvCPMo
-
-If you are using Bazzite's KDE Plasma image, then you can skip the "Making Gnome look more familiar to Windows users" section, and use the steps above to get auto login working in Bazzite KDE. Then finally set Steam Big Picture Mode to auto-start in **Settings → Autostart**.
-
-## No Wi-Fi or wired connection in Bazzite when dual-booting with Windows
+### No Network Connection in Bazzite When Dual-Booting with Windows
 
 If you are dual-booting Windows with Bazzite and your Wi-Fi/wired connection works in Windows but fails in Bazzite sometimes, it is highly likely this is due to Windows Fast Startup.
 
@@ -99,25 +119,24 @@ You can do this by:
 
 Now if you now select the Shutdown option, Windows will shut down completely and not interfere with Bazzite.
 
-## Wi-Fi is slow / Wi-Fi lag spikes
+---
+
+### Wi-Fi is Slow / Wi-Fi Lag Spikes
 
 The Wi-Fi power saving feature in Linux may work poorly on some devices. If the problem is not present in Windows, you may try the solution below. 
 
-If you are using Steam Gaming Mode (i.e. not booting straight into a desktop environment like KDE or GNOME), try:
-
-1. Steam settings -> System -> "Enable Developer Mode"
-2. Steam settings -> Developer -> Uncheck "Enable Wi-Fi Power Management"
-3. Reboot
-
-If the above does not work, and/or for users booting straight into a desktop environment like KDE or Gnome, try:
+> For devices running the `-deck` image, please follow instructions [here](/Handheld_and_HTPC_edition/quirks/#wi-fi-is-slow-wi-fi-lag-spikes).
 
 Open the terminal and run `ip link show`, this will list all your network devices and the output should look something like this:
 
+
 ```
+
 1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
-    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
 2: wlp6s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DORMANT group default qlen 1000
-    link/ether 00:00:00:00:00:00 brd ff:ff:ff:ff:ff:ff permaddr 00:00:00:00:00:00
+link/ether 00:00:00:00:00:00 brd ff:ff:ff:ff:ff:ff permaddr 00:00:00:00:00:00
+
 ```
 
 The device that we are interested in is the Wi-Fi device. In this example (ROG Ally), the Wi-Fi device is called `wlp6s0`.
@@ -125,36 +144,59 @@ The device that we are interested in is the Wi-Fi device. In this example (ROG A
 !!! tip "Another common name for the Wi-Fi device is `wlan0`."
 
 Next, run `iw wlp6s0 get power_save` (change `wlp6s0` if your device name is different) to confirm if power saving is on:
+
 ```
+
 Power save: on
+
 ```
 
-There are different steps to resolve this depending on your current Wi-Fi backend.
-!!! info "[`iwd`](https://wiki.archlinux.org/title/Iwd) has been abandoned due to Intel shifting their priorities away from open source. You may still try it to fix lag spikes caused by [`wpa_supplicant`](https://wiki.archlinux.org/title/Wpa_supplicant), but it may stop working at anytime and is thus highly advisable to [switch your Wi-Fi backend](./#switching-wi-fi-backends) to [`wpa_supplicant`](https://wiki.archlinux.org/title/Wpa_supplicant)."
+We may then configure NetworkManager to disable the power save feature for all Wi-Fi devices. Open a terminal and run
 
-=== "wpa_supplicant (iwd is OFF)"
+```bash
+echo -e "[connection]\nwifi.powersave = 2" | sudo tee /etc/NetworkManager/conf.d/wifi-powersave-off.conf
+systemctl restart NetworkManager
 
-    We are going to configure NetworkManager to not use the power save feature for all Wi-Fi devices. Open a terminal and run
+```
 
-    ```bash
-    echo -e "[connection]\nwifi.powersave = 2" | sudo tee /etc/NetworkManager/conf.d/wifi-powersave-off.conf
-    systemctl restart NetworkManager
-    ```
+Next, run `iw wlp6s0 get power_save` to confirm that power save is off:
 
-    Next, run `iw wlp6s0 get power_save` to confirm that power save is off:
-    ```
-    Power save: off
-    ```
+```
+Power save: off
 
-    !!! warning "This fix may negatively affect the battery life of your laptop or handheld."
-    
-    If you wish to reverse this change, delete the config file:
-    ```bash
-    sudo rm /etc/NetworkManager/conf.d/wifi-powersave-off.conf
-    systemctl restart NetworkManager
-    ```
-    
-=== "iwd (iwd is ON)"
+```
+
+!!! warning "This fix may negatively affect the battery life of your laptop or handheld."
+
+If you wish to reverse this change, delete the config file:
+
+```bash
+sudo rm /etc/NetworkManager/conf.d/wifi-powersave-off.conf
+systemctl restart NetworkManager
+
+```
+
+---
+
+### `iwd` Specific Issues
+
+??? quote "Expand to learn more"
+
+    [`iwd`](https://wiki.archlinux.org/title/Iwd) has been abandoned due to Intel shifting their priorities away from open source. It is no longer included in recent images as it does not work with newer kernels, and these instructions are only kept for the sake of completeness.
+
+    !!! warning "The following are [`iwd`](https://wiki.archlinux.org/title/Iwd) specific issues. It is highly advisable to [switch your Wi-Fi backend](./#switching-wi-fi-backends) to [`wpa_supplicant`](https://wiki.archlinux.org/title/Wpa_supplicant) as the [`iwd`](https://wiki.archlinux.org/title/Iwd) project is no longer maintained by Intel."
+
+    !!! info "On recent images where [`iwd`](https://wiki.archlinux.org/title/Iwd) is removed, your backend will be automatically switched to [`wpa_supplicant`](https://wiki.archlinux.org/title/Wpa_supplicant) during boot up of the new image. The following instructions only apply for images where [`iwd`](https://wiki.archlinux.org/title/Iwd) is still present."
+
+    ---
+
+    #### Switching Wi-Fi Backends
+
+    To switch your Wi-Fi backend, open [Bazzite Portal](/Installing_and_Managing_Software/Bazzite_Portal/), and under the **Troubleshooting** page, select **Change Wi-Fi system back-end**.
+
+    ---
+
+    #### Wi-Fi is slow / Wi-Fi lag spikes - IWD
 
     We are going to configure iwd to not use the power save feature for all Wi-Fi devices. Open a terminal and run
 
@@ -169,135 +211,128 @@ There are different steps to resolve this depending on your current Wi-Fi backen
     ```
 
     !!! warning "This fix may negatively affect the battery life of your laptop or handheld."
-    
+
     If you wish to reverse this change, delete the config file:
     ```bash
     sudo rm /etc/iwd/main.conf
     systemctl restart iwd
     ```
 
----
+    ---
 
-## Error on connecting to Wi-Fi: "Failed to add new connection: 802.1x connections must have IWD provisioning files"
+    #### Error on connecting to Wi-Fi: "Failed to add new connection: 802.1x connections must have IWD provisioning files"
 
-!!! warning "This is an [`iwd`](https://wiki.archlinux.org/title/Iwd) specific issue. It is highly advisable to [switch your Wi-Fi backend](./#switching-wi-fi-backends) to [`wpa_supplicant`](https://wiki.archlinux.org/title/Wpa_supplicant) as the [`iwd`](https://wiki.archlinux.org/title/Iwd) project is no longer maintained by Intel."
+    NetworkManager cannot automatically generate 802.1x connections when using the `iwd` backend.
 
-NetworkManager cannot automatically generate 802.1x connections when using the `iwd` backend.
+    If you need to continue using the `iwd` backend and just want to connect to `eduroam`, follow these steps:
 
-If you need to continue using the `iwd` backend and just want to connect to `eduroam`, follow these steps:
+    ```bash
+    sudo nano /var/lib/iwd/eduroam.8021x
+    ```
 
-```bash
-sudo nano /var/lib/iwd/eduroam.8021x
-```
+    Then add the following:
 
-Then add the following:
+    ```bash
+    [Security]
+    EAP-Method=PEAP
+    EAP-Identity=anonymous@<university.domain>
+    EAP-PEAP-Phase2-Method=MSCHAPV2
+    EAP-PEAP-Phase2-Identity=<username@university.domain>
+    EAP-PEAP-Phase2-Password=<password>
 
-```bash
-[Security]
-EAP-Method=PEAP
-EAP-Identity=anonymous@<university.domain>
-EAP-PEAP-Phase2-Method=MSCHAPV2
-EAP-PEAP-Phase2-Identity=<username@university.domain>
-EAP-PEAP-Phase2-Password=<password>
+    [Settings]
+    AutoConnect=true
+    ```
 
-[Settings]
-AutoConnect=true
-```
+    Make sure to replace `<university.domain>`, `<username@university.domain>` and `<password>` with proper login information. Afterwards, press `Ctrl+X` and `Y` to Save & Exit.
 
-Make sure to replace `<university.domain>`, `<username@university.domain>` and `<password>` with proper login information. Afterwards, press `Ctrl+X` and `Y` to Save & Exit.
+    Now try to connect again. If you still can't connect, execute:
 
-Now try to connect again. If you still can't connect, execute:
+    ```bash
+    nmcli connection modify eduroam 802-1x.phase1-auth-flags 32
+    ```
 
-```bash
-nmcli connection modify eduroam 802-1x.phase1-auth-flags 32
-```
+    And try to connect again.
 
-And try to connect again.
+    ---
 
----
+    #### Error on connecting to Wi-Fi: "IP configuration was unavailable" when connecting to 802.1x wireless networks
 
-## Error on connecting to Wi-Fi: "IP configuration was unavailable" when connecting to 802.1x wireless networks
+    !!! warning "This is an [`iwd`](https://wiki.archlinux.org/title/Iwd) specific issue. It is highly advisable to [switch your Wi-Fi backend](./#switching-wi-fi-backends) to [`wpa_supplicant`](https://wiki.archlinux.org/title/Wpa_supplicant) as the [`iwd`](https://wiki.archlinux.org/title/Iwd) project is no longer maintained by Intel."
 
-!!! warning "This is an [`iwd`](https://wiki.archlinux.org/title/Iwd) specific issue. It is highly advisable to [switch your Wi-Fi backend](./#switching-wi-fi-backends) to [`wpa_supplicant`](https://wiki.archlinux.org/title/Wpa_supplicant) as the [`iwd`](https://wiki.archlinux.org/title/Iwd) project is no longer maintained by Intel."
+    !!! warning "[`iwd`](https://wiki.archlinux.org/title/Iwd) is no longer included in recent images as it does not work with newer kernels. These instructions are only kept for the sake of completeness."
 
-Check the system logs with `ujust logs-this-boot | grep NetworkManager`, you should be able to see that 
+    Check the system logs with `ujust logs-this-boot | grep NetworkManager`, you should be able to see that 
 
-```
-NetworkManager[1563]: <info>  [1770094603.8488] device (wlan0): state change: failed -> disconnected (reason 'none', managed-type: 'full')
-NetworkManager[1563]: <info>  [1770094603.8568] dhcp4 (wlan0): canceled DHCP transaction
-NetworkManager[1563]: <info>  [1770094603.8569] dhcp4 (wlan0): activation: beginning transaction (timeout in 45 seconds)
-NetworkManager[1563]: <info>  [1770094603.8569] dhcp4 (wlan0): state changed no lease
-```
+    ```console
+    NetworkManager[1563]: <info>  [1770094603.8488] device (wlan0): state change: failed -> disconnected (reason 'none', managed-type: 'full')
+    NetworkManager[1563]: <info>  [1770094603.8568] dhcp4 (wlan0): canceled DHCP transaction
+    NetworkManager[1563]: <info>  [1770094603.8569] dhcp4 (wlan0): activation: beginning transaction (timeout in 45 seconds)
+    NetworkManager[1563]: <info>  [1770094603.8569] dhcp4 (wlan0): state changed no lease
+    ```
 
-When using the `iwd` backend, NetworkManager may be unable to obtain a DHCP lease on an Enterprise network if you have connected to it previously on a different backend or a different OS. 
+    When using the `iwd` backend, NetworkManager may be unable to obtain a DHCP lease on an Enterprise network if you have connected to it previously on a different backend or a different OS. 
 
-If you prefer to keep using the `iwd` backend, follow these steps:
+    If you prefer to keep using the `iwd` backend, follow these steps:
 
-```bash
-sudo mkdir -p /etc/iwd/
-sudo nano /etc/iwd/main.conf
-```
+    ```bash
+    sudo mkdir -p /etc/iwd/
+    sudo nano /etc/iwd/main.conf
+    ```
 
-Then add the following:
+    Then add the following:
 
-```ini
-[General]
-AddressRandomization=network
-```
+    ```ini
+    [General]
+    AddressRandomization=network
+    ```
 
-Afterwards, press `Ctrl+X` and `Y` to Save & Exit, then reload `iwd` by running:
+    Afterwards, press `Ctrl+X` and `Y` to Save & Exit, then reload `iwd` by running:
 
-```bash
-systemctl daemon-reload
-systemctl restart iwd
-```
+    ```bash
+    systemctl daemon-reload
+    systemctl restart iwd
+    ```
 
-You should be able to connect to the enterprise network.
-
----
-
-## Switching Wi-Fi Backends
-
-!!! info "[`iwd`](https://wiki.archlinux.org/title/Iwd) has been abandoned due to Intel shifting their priorities away from open source. You may still try it to fix lag spikes caused by [`wpa_supplicant`](https://wiki.archlinux.org/title/Wpa_supplicant), but it may stop working at anytime and is thus highly advisable to [switch your Wi-Fi backend](./#switching-wi-fi-backends) to [`wpa_supplicant`](https://wiki.archlinux.org/title/Wpa_supplicant)."
-
-To switch your Wi-Fi backend, open [Bazzite Portal](/Installing_and_Managing_Software/Bazzite_Portal/), and under the **Troubleshooting** page, select **Change Wi-Fi system back-end**.
+    You should be able to connect to the enterprise network.
 
 ---
 
-## HDMI-CEC Does Not Work Consistently
+## 4. Desktop Environment and System Configuration
 
-In [Bazzite Portal](/Installing_and_Managing_Software/Bazzite_Portal), select **Troubleshoot → Change CEC mode**:
+### Disable Special Character Pop-Up on KDE Plasma
 
-!!! note "`cecd` is known to interfere with wakeup on HTPC setups that use dongles. Try setting dGPU mode and see if HDMI-CEC behavior is consistent."
+KDE Plasma 6.7 added the Plasma Keyboard feature, which shows an on-screen pop-up when certain keys are held for a period.
 
-*   dGPU mode (Legacy): Use the “legacy” cec-control services using `libcec` and `cec-ctl`, known to work pretty well on HTPCs with things like pulse8 and ugreen adaptors. These adapters are typically used to work around dGPUs not having cec pin 13 wired up. 
-*   Native mode (New): Use Valve's newer `linux-cec`/`cecd` system instead and mask the legacy services.
+You may disable it in **System Settings → Keyboard → On-Screen Keyboard → Show popup when holding a key**.
 
-!!! info "Native mode builds `linux-cec` from Valve's upstream GitLab repo and includes the inputattach CEC units and linuxconsoletools, so Pulse-Eight style adapters can be attached to the kernel CEC subsystem. However, Ugreen HDMI Adapters are known to behave inconsistently when using Native mode."
-
-## Nvidia Optimus GPU not detected on laptops
-
-If you are running Bazzite on a laptop with an Nvidia Optimus GPU, you might notice that games are running poorly and seem to be running on the integrated GPU.
-
-In this case, use the preinstalled [Cardwire](https://github.com/OpenGamingCollective/cardwire) app to configure your GPU Power Options. You may simply search **cardwire** to open the app.
-
-> Learn more about Cardwire [here](/Advanced/cardwire)!
-
-!!! info "If you are looking for **Advanced Optimus** functions, we regret to tell you that there are currently **no** working way to dynamically MUX displays outside of some very early work on AMD SmartMUX. Changing MUX settings currently **requires** a reboot."
+![Turning off special characters pop-up|1181x1024, 50%](/img/turn-off-special-char-pop-up.png)
 
 ---
 
-## Flatpak Apps have no Hardware Acceleration on Nvidia
+### Dolphin SMB Share does not work
 
-If you have recently updated Bazzite on a device with an Nvidia GPU, you might notice that Flatpak applications are running poorly and/or have no hardware acceleration, and/or receive a warning about **Nvidia Flatpak Runtime mismatch**.
+This is because Atomic installations handles Groups and Users slightly differently, and puts them somewhere different to where Dolphin expects, so the button to add user to group does not actually work.
 
-In this case, you should update all Flatpaks in **Bazaar**, or select **Update Nvidia Flatpak Runtime** under **Bazzite Portal** → **Manage Bazzite** if you do not want to update other Flatpaks.
+You will need to manually add your user to the **`usershares`** group.
 
-!!! info "Bazzite provides a systemd service that automates this, but you may still need to update it manually in some situations (e.g. No Internet connection on startup). The ideal solution is for upstream Flatpak/Nvidia to improve the way these Runtimes are handled, or to create a package that provides a Flatpak Nvidia driver using system libraries, but those require a lot more work to make possible."
+> Detailed instructions can be found [here](/Advanced/add-user-to-group).
 
 ---
 
-## Waking from sleep doesn't work with some Gigabyte motherboard
+### Setting Bazzite's Desktop Editions to Automatically Login
+
+=== "KDE Plasma"
+
+    Open **System Settings → Colors and Themes → Login Screen**. On that screen, tick **"Automatically log in"**, select your user and for the session, select **"Plasma"** and don't forget to to click on the **"Apply"** button.
+
+=== "GNOME"
+
+    Open the **Settings application → Users**. Click the **Unlock** button in the top right corner. Then switch on **Automatic Login**.
+
+---
+
+### Waking from Sleep Doesn't Work with Some Gigabyte Motherboards
 
 <small>_Why does Life Slumber? ...Because Gigabyte motherboards can't wake from sleep._</small>
 
@@ -307,50 +342,43 @@ This can be fixed by disabling GPP0 and GPP8 wakeup. A hidden ujust command is p
 
 ```bash
 ujust _toggle-gigabyte-wake-fix
+
 ```
 
 ---
 
-## Xbox controller over Bluetooth is stuck on a connecting loop and the Xbox button keeps flashing
+## 5. Application and Software
 
-This is because your controller is not on the latest firmware.
+### Firefox and KeePassXC Does Not Work Together
 
-The easiest solution here is to connect the controller to a Windows machine. Download the Xbox Accessories app and update the controller to the latest firmware. After that, the controller should connect seamlessly. 
+This is because KeePassXC(or other password managers installed via Flatpak) is sandboxed and can only be accessed by a non-sandboxed application.
 
-A more advanced way is to spin up a Windows VM and passthrough the controller to do the firmware update there.
+You may try installing Firefox and KeePassXC via distrobox, though there may be problems regarding hardware acceleration.
 
----
-
-## My Cursor is Flickering/ has Disappeared
-
-This is typically due to bugs in the GPU drivers. You can temporarily disable Hardware Cursors as a workaround.
-
-=== "KDE Plasma"
-
-    Add an environment variable with this command:
-
-    ```bash
-    echo "KWIN_FORCE_SW_CURSOR=1" > ~/.config/environment.d/99-kwin-force-sw-cursor.conf
-    ```
-
-=== "GNOME"
-
-    Add an environment variable with this command:
-
-    ```bash
-    echo "MUTTER_DEBUG_DISABLE_HW_CURSORS=1" > ~/.config/environment.d/99-mutter-disable-hw-cursor.conf
-    ```
-    
-!!! warning "This fix may negatively affect the battery life of your laptop or handheld."
+!!! info "Alternatively, you may also try [this guide](https://discourse.flathub.org/t/how-to-run-firefox-and-keepassxc-in-a-flatpak-and-get-the-keepassxc-browser-add-on-to-work/437). Note that Bazzite officially neither maintains nor endorses the aforementioned guide and it is only included for the sake of completeness. Only follow it at **your own risk**. "
 
 ---
 
-## Dolphin SMB Share does not work
+### HTPC Legacy Hardware Setup
 
-This is because Atomic installations handles Groups and Users slightly differently, and puts them somewhere different to where Dolphin expects, so the button to add user to group does not actually work.
+As Steam Gaming Mode is not supported on some GPUs, the guide below is a way to set up a similar experience using Bazzite's Desktop image.
 
-You will need to manually add your user to the **`usershares`** group.
+[Enable auto-login](#setting-bazzites-desktop-editions-to-automatically-login) and set Steam to automatically launch in Steam's Big Picture Mode for a decent couch gaming experience.
 
-> Detailed instructions can be found [here](/Advanced/add-user-to-group).
+There is a video guide that you can follow for Bazzite's GNOME Desktop image using a Nvidia GPU (before Nvidia hardware could run Steam Gaming Mode, but same idea):
+
+https://www.youtube.com/watch?v=F9l-RQvCPMo
+
+!!! info "If you are using Bazzite's KDE Plasma image, then you can skip the "Making Gnome look more familiar to Windows users" section, and simply enable auto-login and set Steam Big Picture Mode to auto-start in **Settings → Autostart**."
+
+---
+
+### Steam Big Picture Mode is slow
+
+When you select **Steam Menu → View → Big Picture** the user interface runs sluggishly, while the games that run through the interface works smoothly.
+
+If you encounter this issue, close Steam completely and start Steam using the **Steam Big Picture Mode** menu shortcut. Also make sure that **Steam Settings → Interface → Enable GPU accelerated rendering in web views (requires restart)** is enabled in the Steam settings.
+
+> **Note**: This fix also fixes the performance issues in Steam Gaming Mode on Nvidia GPUs, however, this comes with a drawback that the Steam menu and side menu sometimes do not render properly.
 
 ---

--- a/src/General/issues_and_resolutions.md
+++ b/src/General/issues_and_resolutions.md
@@ -45,7 +45,7 @@ You may try installing Firefox and KeePassXC via distrobox, though there may be 
 
 ---
 
-## Gamepads and handheld joysticks don't work in Desktop Mode
+## Gamepads and Handheld Joysticks Don't Work in Desktop Mode
 
 Open **Steam Settings → Controller → Non-Game Controller Layouts → Desktop Layout**. Click **Edit** → **Enable Steam Input** and configure how the controller needs to act as keyboard and mouse in Desktop Mode.
 
@@ -102,6 +102,14 @@ Now if you now select the Shutdown option, Windows will shut down completely and
 ## Wi-Fi is slow / Wi-Fi lag spikes
 
 The Wi-Fi power saving feature in Linux may work poorly on some devices. If the problem is not present in Windows, you may try the solution below. 
+
+If you are using Steam Gaming Mode (i.e. not booting straight into a desktop environment like KDE or GNOME), try:
+
+1. Steam settings -> System -> "Enable Developer Mode"
+2. Steam settings -> Developer -> Uncheck "Enable Wi-Fi Power Management"
+3. Reboot
+
+If the above does not work, and/or for users booting straight into a desktop environment like KDE or Gnome, try:
 
 Open the terminal and run `ip link show`, this will list all your network devices and the output should look something like this:
 

--- a/src/General/issues_and_resolutions.zh_CN.md
+++ b/src/General/issues_and_resolutions.zh_CN.md
@@ -1,0 +1,382 @@
+---
+title: 常见问题及解决方法
+---
+
+# 常见问题及解决方法
+
+## 目录
+
+- [显卡与显示相关](#1-display-and-graphics)
+- [手柄和游戏输入相关](#2-controllers-and-gaming-inputs)
+- [网络相关](#3-network-and-wi-fi)
+- [桌面环境配置相关](#4-desktop-environment-and-system-configuration)
+- [特定软件相关](#5-application-and-software)
+
+---
+
+## 1. 显卡与显示相关
+
+### 光标闪烁或不显示
+
+比较常见的原因是显卡驱动的问题。作为临时修复，一般可以强制软件渲染光标。
+
+=== "KDE Plasma"
+
+    使用以下命令设置对应的环境变量：
+
+    ```bash
+    echo "KWIN_FORCE_SW_CURSOR=1" > ~/.config/environment.d/99-kwin-force-sw-cursor.conf
+    ```
+
+=== "GNOME"
+
+    使用以下命令设置对应的环境变量：
+
+    ```bash
+    echo "MUTTER_DEBUG_DISABLE_HW_CURSORS=1" > ~/.config/environment.d/99-mutter-disable-hw-cursor.conf
+    ```
+
+!!! warning "该修复可能会影响设备的电池续航能力。"
+
+---
+
+### Flatpak 程序无法使用 NVIDIA 硬件加速
+
+在 Bazzite 进行系统更新之后，NVIDIA 用户有时会碰到 Flatpak 安装的程序性能较差和/或失去视频加速的情况，通常伴随 **NVIDIA Flatpak 运行时组件版本不匹配**一类的警告。
+
+此时需要通过 **Bazaar** 升级所有 Flatpak 包，或在 **Bazzite Portal** → **Manage Bazzite** 下选择 **Update Nvidia Flatpak Runtime**。
+
+!!! info "Bazzite 在最近的版本提供了一个能够自动进行相关更新的脚本，但如果碰到类似于启动时没有网络连接这一类的情况，则可能仍需手动更新。最理想的解决方案需要上游 Flatpak 或者 NVIDIA 改善运行时组件的配置方式，或提供直接调用系统组件的“假包”，但这些方法都超出了 Bazzite 的能力范围。"
+
+---
+
+### HDMI-CEC 无法稳定运作
+
+在 [Bazzite Portal](/Installing_and_Managing_Software/Bazzite_Portal) 下选择 **Troubleshoot → Change CEC mode**。
+
+!!! note "`cecd` 目前已知在需要转接头的 HTPC 配置下可能无法使用唤醒相关功能。如有需要，可以尝试 dGPU 模式下是否出现类似问题。"
+
+*   dGPU 模式（旧版方法）：基于`libcec`和`cec-ctl`的传统配置，一般在 HTPC 环境下和 pulse8 和绿联（Ugreen）转接头的兼容性较好，有时也能解决一些独立显卡上 CEC 13 针没有连通的问题。
+*   原生模式（新方法）：走 Valve 维护的`linux-cec`/`cecd`系统，并屏蔽旧版组件。
+
+!!! info "原生模式直接编译运行 Valve 上游的 GitLab 仓库发布的`linux-cec`，并包含 inputattach 的 CEC 组件和 linuxconsoletools，因此 Pulse-Eight 系列的转接头往往能够无缝衔接 Linux 内核的 CEC 子系统，但绿联转接头目前总体兼容性会比较差。"
+
+---
+
+### 笔记本电脑的 NVIDIA Optimus 显卡无法识别
+
+在安装了 NVIDIA Optimus 显卡的笔记本电脑上运行 Bazzite 时，可能会出现游戏默认运行在集成显卡上因此出现性能损失的情况。
+
+此时建议通过预装的 [Cardwire](https://github.com/OpenGamingCollective/cardwire) 实用工具来配置显卡相关的功能。
+
+> 关于 Cardwire 的更多信息请参考[这里](/Advanced/cardwire)。
+
+!!! info "更高级的 Optimus 相关功能在 Linux 上并不可用，比如动态切换（MUX）的功能目前只有 AMD SmartMUX 有内核层面完成的一些前期工作。MUX 相关功能的设置目前需要重启才能生效。"
+
+---
+
+## 2. 手柄和游戏输入相关
+
+### 桌面模式下游戏控制器和掌机摇杆无法使用
+
+在 **Steam 设置 → Controller → Non-Game Controller Layouts → Desktop Layout** 下选择 **Edit** → **Enable Steam Input**，按照桌面模式需要的键盘和鼠标的操作方式进行修改。
+
+!!! Tip "通常需要将 **Right Joystick Sensitivity** 调低到 50-80% 附近，否则鼠标移动速度会非常快。"
+
+!!! Notice "KDE Plasma 6.7 新增了手柄直接控制桌面的功能，但其与 Steam 目前提供的模拟方式冲突，因此两者一般只需选一个启用。"
+
+---
+
+### Xbox 控制器通过蓝牙连接时陷入匹配循环，Xbox 按钮闪烁
+
+该问题通常是因为控制器的固件需要更新。
+
+最简单的方法是将其连接到运行 Windows 的实体机上，在上面安装 Xbox Accessories 程序以进行控制器的固件更新。更新完成后一般立刻就能正常连接。
+
+更高级的方法是部署一台 Windows 的虚拟机并将控制器的连接重定向到虚拟机中以进行更新。
+
+---
+
+## 3. 网络相关
+
+### 和 Windows 双启动的配置下无法连接网络
+
+如果双启动配置下 Windows 的有线或无线网络能够正常连接但在 Bazzite 下不行，很有可能是 Windows 快速启动导致的问题。
+
+启用快速启动时，Windows 会在关机时改为进入一种介于完全关机和休眠之间的状态，这能够缩短开机所需的时间，但也会导致网卡等特定硬件在启动到非 Windows 环境下时状态异常。一种绕过方法是在 Windows 中选择“重新启动”而非“关机”，这样保证进入 Linux 时能够完整重置所有硬件状态。但更推荐的方法一般是直接禁用快速启动：
+
+-   进入**控制面板**
+-   选择**电源选项**（在**硬件和声音**分类下）
+-   选择**选择电源按钮的功能**
+-   点击**更改当前不可用的设置**
+-   取消勾选**启用快速启动（推荐）**
+-   （可选）取消勾选**休眠**（和快速启动存在相似的问题）
+-   选择**保存修改**
+
+![在 Windows 里禁用快速启动](../img/disable-windows-fast-startup.gif)
+
+关闭按快速启动后，Windows 在关机时也会完整重置硬件，不再干扰 Bazzite 下的正常运行。
+
+---
+
+### Wi-Fi 慢或有明显卡顿
+
+Linux 默认的 Wi-Fi 节能设置有时会在特定网卡硬件下出现问题。如果该问题在 Windows 下不出现，可以考虑以下的解决方法。
+
+> 掌机版镜像的用户应参考[这一指南](/Handheld_and_HTPC_edition/quirks/#wi-fi-is-slow-wi-fi-lag-spikes)。
+
+在终端运行`ip link show`，以列出所有的网络设备，输出一般类似于这样：
+
+
+```
+
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN mode DEFAULT group default qlen 1000
+link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+2: wlp6s0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue state UP mode DORMANT group default qlen 1000
+link/ether 00:00:00:00:00:00 brd ff:ff:ff:ff:ff:ff permaddr 00:00:00:00:00:00
+
+```
+
+我们要寻找的是无线网卡的名称。比如在以上的输出中（ROG Ally），对应的名称是`wlp6s0`。
+
+!!! tip "`wlan0`是另一个比较常见的默认名称。"
+
+接下来运行`iw wlp6s0 get power_save`（将`wlp6s0`对应替换成你上一步拿到的名字）以查询节能模式的状态：
+
+```
+
+Power save: on
+
+```
+
+接下来配置 NetworkManager 禁用所有无线网络设备的节能模式。在终端运行
+
+```bash
+echo -e "[connection]\nwifi.powersave = 2" | sudo tee /etc/NetworkManager/conf.d/wifi-powersave-off.conf
+systemctl restart NetworkManager
+
+```
+
+再次运行`iw wlp6s0 get power_save`以确认节能模式已经关闭：
+
+```
+Power save: off
+
+```
+
+!!! warning "该修复可能会影响设备的电池续航能力。"
+
+如果要还原设置，只需要删除之前保存的配置文件：
+
+```bash
+sudo rm /etc/NetworkManager/conf.d/wifi-powersave-off.conf
+systemctl restart NetworkManager
+
+```
+
+---
+
+### `iwd`相关问题
+
+??? quote "更多信息"
+
+    由于 Intel 将开源开发的优先级降低，[`iwd`](https://wiki.archlinux.org/title/Iwd)目前基本上已经不再受维护，且在较新的 Linux 内核上已经无法正常工作，因此较新的 Bazzite 版本已经不再包含 iwd。以下内容仅作为历史信息供参考。
+
+    !!! warning "以下问题只针对[`iwd`](https://wiki.archlinux.org/title/Iwd)。由于 Intel 基本不再维护 iwd，Bazzite 强烈建议将[无线网络后端系统更换](./#switching-wi-fi-backends)回[`wpa_supplicant`](https://wiki.archlinux.org/title/Wpa_supplicant)。"
+
+    !!! info "在较新的移除了[`iwd`](https://wiki.archlinux.org/title/Iwd)的镜像上，Bazzite 在启动时会自动把无线网络后端系统切换为[`wpa_supplicant`](https://wiki.archlinux.org/title/Wpa_supplicant)。以下内容只适用于仍安装了[`iwd`](https://wiki.archlinux.org/title/Iwd)的镜像。"
+
+    ---
+
+    #### 更换无线网络后端系统
+
+    在 [Bazzite Portal](/Installing_and_Managing_Software/Bazzite_Portal/) 的 **Troubleshooting** 页下选择 **Change Wi-Fi system back-end**。
+
+    ---
+
+    #### Wi-Fi 慢或有明显卡顿 （IWD）
+
+    配置 iwd 在所有无线网络设备上禁用节能模式：
+
+    ```bash
+    echo -e "[DriverQuirks]\nPowerSaveDisable = *" | sudo tee /etc/iwd/main.conf
+    systemctl restart iwd
+    ```
+
+    运行`iw wlp6s0 get power_save`以确认节能模式已经关闭：
+    ```
+    Power save: off
+    ```
+
+    !!! warning "该修复可能会影响设备的电池续航能力。"
+
+    如果要还原设置，只需要删除之前保存的配置文件：
+    ```bash
+    sudo rm /etc/iwd/main.conf
+    systemctl restart iwd
+    ```
+
+    ---
+
+    #### 连接无线网络时报错："Failed to add new connection: 802.1x connections must have IWD provisioning files"
+
+    NetworkManager 在使用`iwd`后端时无法自动生成 802.1x 的连接文件。
+
+    如果必须使用`iwd`后端，则可以按以下步骤手动配置连接。对于`eduroam`：
+
+    ```bash
+    sudo nano /var/lib/iwd/eduroam.8021x
+    ```
+
+    在文件里输入以下内容：
+
+    ```bash
+    [Security]
+    EAP-Method=PEAP
+    EAP-Identity=anonymous@<university.domain>
+    EAP-PEAP-Phase2-Method=MSCHAPV2
+    EAP-PEAP-Phase2-Identity=<username@university.domain>
+    EAP-PEAP-Phase2-Password=<password>
+
+    [Settings]
+    AutoConnect=true
+    ```
+
+    注意将`<university.domain>`、`<username@university.domain>`和`<password>`对应换成你的信息。完成后按`Ctrl+X`和`Y`以保存并退出编辑器。
+
+    之后即可再次尝试连接。如果仍然不行，尝试以下命令：
+
+    ```bash
+    nmcli connection modify eduroam 802-1x.phase1-auth-flags 32
+    ```
+
+    之后再次尝试连接。
+
+    ---
+
+    #### 连接 802.1x 无线网络时报错："IP configuration was unavailable"
+
+    !!! warning "以下问题只针对[`iwd`](https://wiki.archlinux.org/title/Iwd)。由于 Intel 基本不再维护 iwd，Bazzite 强烈建议将[无线网络后端系统更换](./#switching-wi-fi-backends)回[`wpa_supplicant`](https://wiki.archlinux.org/title/Wpa_supplicant)。"
+
+    !!! warning "iwd 在较新的 Linux 内核上已经无法正常工作，因此较新的 Bazzite 版本已经不再包含 iwd。以下内容仅作为历史信息供参考。"
+
+    通过`ujust logs-this-boot | grep NetworkManager`时可能注意到以下内容：
+
+    ```console
+    NetworkManager[1563]: <info>  [1770094603.8488] device (wlan0): state change: failed -> disconnected (reason 'none', managed-type: 'full')
+    NetworkManager[1563]: <info>  [1770094603.8568] dhcp4 (wlan0): canceled DHCP transaction
+    NetworkManager[1563]: <info>  [1770094603.8569] dhcp4 (wlan0): activation: beginning transaction (timeout in 45 seconds)
+    NetworkManager[1563]: <info>  [1770094603.8569] dhcp4 (wlan0): state changed no lease
+    ```
+
+    使用`iwd`后端时，如果同一个企业无线网络已经在另一个操作系统下连接过或使用不同的后端系统连接过，则 NetworkManager 可能无法正确获取 DHCP 租约，导致 IP 配置失败。
+
+    如果必须使用`iwd`后端，则可以按以下步骤进行配置。
+
+    ```bash
+    sudo mkdir -p /etc/iwd/
+    sudo nano /etc/iwd/main.conf
+    ```
+
+    在文件里输入以下内容：
+
+    ```ini
+    [General]
+    AddressRandomization=network
+    ```
+
+    完成后按`Ctrl+X`和`Y`以保存并退出编辑器。使用以下命令重新启动 iwd：
+
+    ```bash
+    systemctl daemon-reload
+    systemctl restart iwd
+    ```
+
+    之后应该可以正常连接企业网络。
+
+---
+
+## 4. 桌面环境配置相关
+
+### KDE Plasma 禁用特殊字符输入弹窗
+
+KDE Plasma 6.7 为 Plasma 屏幕键盘新增了在长按特定键时弹窗以输入特殊字符的功能。
+
+要禁用该功能的话，取消勾选**系统设置 → 键盘 → 屏幕键盘 → 备选字符：按住按键时弹出**。
+
+![禁用特殊字符输入弹窗|1181x1024, 50%](/img/turn-off-special-char-pop-up.png)
+
+---
+
+### Dolphin 无法使用 SMB 协议共享的网络目录
+
+Fedora Atomic 的系统的用户和组的配置方式与传统 Linux 有所不同，因此 Dolphin 提供的将用户添加到相关组的按钮实际无法工作。
+
+需要将用户手动添加到**`usershares`**组。
+
+> [这篇指南](/Advanced/add-user-to-group)提供了详细信息。
+
+---
+
+### Bazzite 桌面版配置自动登录
+
+=== "KDE Plasma"
+
+    在**系统设置 → 颜色和主题 → 登录屏幕**下勾选**"自动登录"**。“作为用户”选择你的用户名，“跟随会话”选择**"Plasma"**。设置完成后选择“应用”。
+
+=== "GNOME"
+
+    在**设置 → 用户**下，选择右上角的**解锁**，然后勾选**自动登录**。
+
+---
+
+### 一些技嘉主板无法从睡眠状态唤醒
+
+<small>_生命因何而沉睡？因为你技嘉睡死过去了。_</small>
+
+一些技嘉主板在系统挂起后无法正常恢复，屏幕无法点亮，只能重新启动。
+
+目前的解决方法是禁用 GPP0 和 GPP8 唤醒。Bazzite 为此提供了一条隐藏的 ujust 指令：
+
+```bash
+ujust _toggle-gigabyte-wake-fix
+
+```
+
+---
+
+## 5. 特定软件相关
+
+### Firefox 和 KeePassXC 无法集成
+
+KeePassXC （或任何其他通过 Flatpak 安装的密码管理器）因 Flatpak 沙盒限制，默认无法访问其他程序的环境。
+
+一种方法是通过 Distrobox 安装 Firefox 和 KeePassXC，但这样反过来可能会有视频硬件加速相关的问题。
+
+!!! info "你也可以尝试[该指南](https://discourse.flathub.org/t/how-to-run-firefox-and-keepassxc-in-a-flatpak-and-get-the-keepassxc-browser-add-on-to-work/437)提供的方法，但请注意该方法需要修改 Flatpak 的沙盒策略并配置自定义的浏览器扩展项。该方法并非由 Bazzite 设计，也无法支持，仅作为参考信息提供。"
+
+---
+
+### 在老设备上配置掌机模式
+
+对于不支持 Steam 游戏模式的显卡，只使用 Bazzite 桌面版镜像，也能实现类似于掌机版的界面功能。
+
+[启用自动登录](#setting-bazzites-desktop-editions-to-automatically-login)，并设置 Steam 开机自启动大屏幕模式，即可得到类似于掌机版的操作体验。
+
+使用 Bazzite 桌面版的 GNOME 镜像的 NVIDIA 用户，可以参考这个视频指南（视频制作时 NVIDIA 显卡尚无法运行 Steam 游戏模式，但底层原理基本一致） ：
+
+https://www.youtube.com/watch?v=F9l-RQvCPMo
+
+!!! info "如果你的镜像自带的是 KDE Plasma 桌面环境，则可以跳过"Making Gnome look more familiar to Windows users"的部分。只需启用自动登录并在**系统设置 → 自动启动**中配置 Steam 大屏幕模式即可。"
+
+---
+
+### Steam 大屏幕模式性能较差
+
+有时 Steam 大屏幕模式的界面本身较为卡顿，但从中启动的游戏不受影响。
+
+如果碰到这类问题，需要完全退出 Steam，并通过 **Steam 大屏幕模式**的菜单项重新启动。另外应确保 **Steam 设置 → 界面 → 在网页视图中启用 GPU 加速渲染（需要重启）**为勾选状态。
+
+> 该修复有时也能解决使用 NVIDIA 显卡时 Steam 游戏模式的一些问题，但同时可能会导致 Steam 菜单和边栏出现渲染错误。
+
+---

--- a/src/Handheld_and_HTPC_edition/Handheld_Wiki/ASUS_ROG_Ally.md
+++ b/src/Handheld_and_HTPC_edition/Handheld_Wiki/ASUS_ROG_Ally.md
@@ -26,7 +26,12 @@ title: ASUS Handhelds
 - Changing A/C power sometimes leads to a stuck TDP.
   - This happens when removing the charger while in standby.
   - Attaching and removing the charger while not in standby is a workaround.
-- Some users report that the mic sounds garbled
+- Audio is Soft
+  - There are two audio devices that appear on the Rog Ally:
+    - **Family 17h/19h/1ah HD Audio Controller**
+    - **ROG Ally**
+  - Both affect each other's audio volume, so they must be at the same volume level.
+- Mic sounds garbled
   - Set the mic/input volume to 10%-15% in settings may resolve this issue
   - The input profile in Discord Settings may also need to be set to **Noice Cancellation**.
 - The "Auto UMA" setting in UEFI/BIOS may cause crashes in some games.
@@ -36,13 +41,14 @@ title: ASUS Handhelds
   - This issue may also be present during charging and sleeping.
 - The Ally does **not** support button holding for the Steam or QAM buttons.
   - Steam Input's chords may not work by default.
-    - Swapping the Start/Select button(s) can be used as a workaround.
+  - Swapping the Start/Select button(s) can be used as a workaround.
 - Suspend may be broken if SMT is disabled
 - Fingerprint sensor driver may not work.
 - Storage may show duplicate drives.
   - This is a visual bug, do **not** attempt to format this drive!
 - Turning on the wake animation when resuming from sleep may cause the device to act erratically.
   - Steam's top and bottom panels may be missing when this bug triggers.
+
 
 #### CPU Boost?
 

--- a/src/Handheld_and_HTPC_edition/Handheld_Wiki/Ayaneo_Handhelds.md
+++ b/src/Handheld_and_HTPC_edition/Handheld_Wiki/Ayaneo_Handhelds.md
@@ -8,25 +8,28 @@ title: Ayaneo Handhelds
 
     Sleep functionality requires a BIOS update. Note that this wiki may contain outdated information.
 
+## Known Issues
+
+- Suspending the device requires the latest BIOS update.
+  - Reports of controller issues on wake have reported inconsistency. Enabling "full initial usb support" in Bios seems to have an impact on how frequent the issue is.
+- VRAM size option is missing from BIOS as it's controlled by AYASPACE application under windows.
+- RGB may need to controlled using the HueSync Decky Plugin.
+
+> You can still change the amount of UMA buffer size using [Smokeless_UMAF](https://github.com/DavidS95/Smokeless_UMAF), but this method has its own associated risks. Only proceed **at your own risk**.
+
+---
+
 ## Ayaneo Geek 1S
 
 ![photo_5875160389711413569_y|663x500, 100%](../../img/Ayaneo_Geek_1S.jpeg)
 
 ### Known Issues
 
-#### Bazzite 44 Known Issues
+> See [here](#known-issues).
 
-- No RGB Control, please try the Huesync Decky Plugin.
+---
 
-#### Other Known Issues
-
-- Suspending the device requires the latest BIOS update.
-  - Reports of controller issues on wake have reported inconsistency. Enabling "full initial usb support" in Bios seems to have an impact on how frequent the issue is.
-- VRAM size option is missing from BIOS as it's controlled by AYASPACE application under windows. 
-
-> You can still change the amount of UMA buffer size using [Smokeless_UMAF](https://github.com/DavidS95/Smokeless_UMAF), but this method has its own associated risks. Only proceed **at your own risk**.
-
-### e-GPU Support:
+## e-GPU Support:
 
 Using e-GPU via Thunderbolt 3, 4 and USB4 enclosures over USB4 are partially supported.
 
@@ -41,8 +44,12 @@ Using e-GPU via Thunderbolt 3, 4 and USB4 enclosures over USB4 are partially sup
   
     Currently untested but _may_ work with the “-nvidia-deck” variant of bazzite.
 
-### External Resource
+---
+
+## External Resource
 
 Check out the [original thread](https://universal-blue.discourse.group/t/ayaneo-geek-1s-2s-linux-bazzite-support-is-already-almost-there-lets-add-them-to-the-officially-supported-devices/1046) for more information and updates on this device.
 
-Ayaneo Geek 1s is (as of April 2025) the only Ryzen 7000 handheld which is yet to receive the EC update that increase battery life. You can follow and report [on this discord thread](https://discord.com/channels/717181357109018694/1301507866754289745).
+Ayaneo Geek 1S is (as of April 2025) the only Ryzen 7000 handheld which is yet to receive the EC update that increase battery life. You can follow and report [on this discord thread](https://discord.com/channels/717181357109018694/1301507866754289745).
+
+---

--- a/src/Handheld_and_HTPC_edition/Handheld_Wiki/Ayn_Handhelds.md
+++ b/src/Handheld_and_HTPC_edition/Handheld_Wiki/Ayn_Handhelds.md
@@ -56,3 +56,5 @@ title: Ayn Handhelds
 - Mouse input may break in Desktop Mode.
 
 > See [General Issues](#general-issues)
+
+---

--- a/src/Handheld_and_HTPC_edition/Handheld_Wiki/GPD_Handhelds.md
+++ b/src/Handheld_and_HTPC_edition/Handheld_Wiki/GPD_Handhelds.md
@@ -11,7 +11,9 @@ title: GPD Handhelds
 ## General Information & Tweaks
 
 - Adjust RGB with Steam Gaming Mode or via Huesync Decky Plugin.
-- GPD devices also have a physical switch you can toggle to enable a separate desktop/mouse mode.
+- GPD devices typically have a physical switch that can be toggled to enable a separate desktop/mouse mode.
+
+---
 
 ## General Issues
 

--- a/src/Handheld_and_HTPC_edition/Handheld_Wiki/Lenovo_Legion_Go.md
+++ b/src/Handheld_and_HTPC_edition/Handheld_Wiki/Lenovo_Legion_Go.md
@@ -12,9 +12,7 @@ title: Lenovo Handhelds
 
 ![legion_go|690x387, 100%](../../img/legion_go.jpeg)
 
-### Optional Tweaks
-
-- Configure the OpenGamepadUI Overlay by opening it with <kbd>Legion Space</kbd>+:material-gamepad-circle-right:
+---
 
 ### Known Issues
 
@@ -24,9 +22,11 @@ title: Lenovo Handhelds
 - Adaptive/auto display brightness is currently broken.
   - Manual brightness slider in Steam's UI should still work.
 - Updating UEFI/BIOS and can be done by using ```fwupd``` or the "Firmware" flatpak, or in Windows if available, **at your own risk**.
-	- **It is advised to disable Secure Boot before attempting a firmware update**
+  - **It is advised to disable Secure Boot before attempting a firmware update!**
 - OGUI (OpenGamepadUI) will not control TDP or CPU Behavior at this time for Legion Go 2 devices, Decky or OGUI plugins may be needed for additional controls
 - As of Deck 44, Charge limits can be set via desktop mode under power settings for you chosen Desktop Environment, the feature is not yet available in OGUI or the Steam QAM
+
+---
 
 ### BIOS update breaks Secure Boot key
 
@@ -43,6 +43,8 @@ If your screen doesn't display the correct output or looks grainy, noisy, or odd
 ```bash
 mv ~/.config/kwinoutputconfig.json ~/.config/kwinoutputconfig.json.old
 ```
+
+---
 
 ## External Resource
 

--- a/src/Handheld_and_HTPC_edition/Handheld_Wiki/OneXPlayer_Handhelds.md
+++ b/src/Handheld_and_HTPC_edition/Handheld_Wiki/OneXPlayer_Handhelds.md
@@ -8,10 +8,16 @@ title: OneXPlayer Handhelds
 
     This wiki may contain outdated information.
 
+---
+
 ## OneXPlayer X1
 
 ![onexplayer-x1|690x328, 100%](../../img/onexplayer-x1.jpeg)
 
+---
+
 ### Known Issues
 
 - Vibration intensity adjustment is not supported yet
+
+---

--- a/src/Handheld_and_HTPC_edition/Handheld_Wiki/Steam_Deck.md
+++ b/src/Handheld_and_HTPC_edition/Handheld_Wiki/Steam_Deck.md
@@ -8,27 +8,23 @@ title: Steam Deck
 
 ![Steam Deck LCD|690x348, 100%](../../img/Steam_Deck_LCD.jpeg)
 
+---
+
 ### BIOS Updates
-It is recommended to enter `ujust enable-deck-bios-firmware-updates` in the terminal to receive Steam Deck BIOS updates.
+
+It is recommended to run `ujust enable-deck-bios-firmware-updates` in the terminal to receive Steam Deck BIOS updates.
+
+---
 
 ### Why Bazzite over SteamOS?
 
-Both SteamOS and Bazzite use Steam Gaming Mode and share packages between each other, but what about differences under the hood?  Bazzite should have most of the functionality from SteamOS with Steam Gaming Mode working as intended.
+> See [**SteamOS comparison guide**](/General/SteamOS_Comparison.md).
 
-- It should function nearly identical to SteamOS.
-  - The Quick Access Menu (QAM) which is accessed with the <kbd>...</kbd> button on Steam Deck is functional for TDP, framerate limiting, scaling, etc. like on SteamOS.
-  - The same popular third-party software like [Decky Loader](https://decky.xyz/), [Emudeck](https://www.emudeck.com/), [RetroDeck](https://retrodeck.net/), etc. should install and function properly.
-- Reaping the benefits of [Fedora Atomic Desktop](https://fedoraproject.org/atomic-desktops/):
-  - Layer Fedora packages to the image without losing them between updates/reboots.
-  - Roll back system updates from the last 90 days.
-  - Alternate desktop environments available.
-- Bazzite includes newer versions of base packages than SteamOS which means Bazzite is always ahead of SteamOS in terms of Steam Gaming Mode and Desktop Mode features.
-  - Newer package upgrades including the Linux kernel and drivers.
-  - Regressions may occur more often since Bazzite upgrades base packages faster than SteamOS does.
-
->If you want to see a more in-depth comparison, read our [**SteamOS comparison guide**](/General/SteamOS_Comparison.md).
+---
 
 ### Known Issues
 
-- (Steam Deck OLED) The brightness is not properly restored when changing refresh rate.
-- (Steam Deck OLED) MangoHUD does not report GPU clocks.
+- (Steam Deck OLED) The brightness may not be properly restored when changing refresh rate.
+- (Steam Deck OLED) MangoHUD may not report GPU clocks.
+
+---

--- a/src/Handheld_and_HTPC_edition/Handheld_Wiki/Steam_Deck.zh_CN.md
+++ b/src/Handheld_and_HTPC_edition/Handheld_Wiki/Steam_Deck.zh_CN.md
@@ -1,0 +1,30 @@
+---
+title: Steam Deck
+---
+
+# Steam Deck
+
+## Steam Deck （LCD 和 OLED 型号）
+
+![Steam Deck LCD|690x348, 100%](../../img/Steam_Deck_LCD.jpeg)
+
+---
+
+### BIOS 更新
+
+建议运行一次`ujust enable-deck-bios-firmware-updates`，以在系统更新时包括 Steam Deck 的 BIOS 更新。
+
+---
+
+### Bazzite 和 SteamOS 比有什么优势？
+
+> 请参考 [**SteamOS 对比指南**](/General/SteamOS_Comparison.md)。
+
+---
+
+### 已知问题
+
+- (Steam Deck OLED) 更改刷新率时，屏幕亮度可能无法正常还原；
+- (Steam Deck OLED) MangoHUD 可能无法报告 GPU 频率相关信息。
+
+---

--- a/src/Handheld_and_HTPC_edition/Handheld_Wiki/index.md
+++ b/src/Handheld_and_HTPC_edition/Handheld_Wiki/index.md
@@ -33,25 +33,13 @@ _Click the name of each hardware to view post-installation setup, known working 
 
 ---
 
-## OGUI Setup
-
-!!! info "[OpenGamepadUI(OGUI)](https://github.com/ShadowBlip/OpenGamepadUI) is intended and enabled by default for handhelds that are **not** the Steam Deck."
-
-1. Double tap :material-microsoft-xbox-controller-menu: or press :material-microsoft-xbox:/:material-sony-playstation:/:material-steam: + :material-gamepad-circle-right: to access OpenGamepadUI overlay in Steam Gaming Mode.
-
-2. Select the controller icon to change the change the Emulated controller type.
-
-!!! note "Gyro functionality **requires** DualSense emulation, though RGB can still be controlled using the Huesync Decky Plugin without it."
-
----
-
 ## TDP Controls
 
 ![TDP|409x1004, 33%](/img/TDP.png) ![OGUI Power Profiles|1920x1200, 30%](/img/OGUI_Profile.jpg)
 
 There are a few options for TDP Controls that work with Bazzite:
 
-!!! info "If you open OpenGamepadUI and see the message **Waiting for PowerStation service...**, this means your device does not use PowerStation for TDP. This is completely normal and is the expected behavior."
+!!! info "If you open OpenGamepadUI and see the message `Waiting for PowerStation service...`, this means your device does not use PowerStation for TDP. This is completely normal and can be safely ignored."
 
 !!! tip "If detailed TDP configurations cannot be found, try selecting the **Performance** profile → scroll down and enable TDP and GPU Clocks. This should enable detailed TDP configuration in Watts."
 
@@ -59,24 +47,27 @@ There are a few options for TDP Controls that work with Bazzite:
 
     If your device's TDP can be controlled via SteamOS Manager, the option will be available here. If it does not appear, check OpenGamepadUI or use other means of adjusting the TDP of your device.
     
-    - This menu can be accessed anytime using the Quick Access Menu button (varies by handheld) or by pressing :material-microsoft-xbox:/:material-sony-playstation:/:material-steam: + :material-gamepad-circle-down:.
+    !!! info "See how to open QAM [here](#how-do-i-open-the-qam)."
+    
     - Select the **:material-lightning-bolt: Lightning Bolt Icon** and enable **Advanced** options
     - TDP can then be changed by using the dedicated TDP Dropdown.
-    - Custom TDP may be set by selecting "Custom", scrolling down and toggling "Custom TDP", then changing the TDP slider that appears.
+    - Custom TDP may be set by selecting **Custom**, scrolling down and toggling **Custom TDP**, then changing the **TDP slider** that appears.
     
     > [These devices](https://github.com/ublue-os/bazzite/blob/main/system_files/desktop/shared/usr/libexec/hwsupport/steamos-manager-hardware) will use this method by default.
   
 === "OpenGamepadUI (OGUI)"
 
     This is the 2nd place where you may find TDP controls for your device. In this menu, TDP controls are provided by [PowerStation](https://github.com/ShadowBlip/PowerStation). If your device can be configured via the Steam QAM, performance configurations may or may not be available here. You may use any of the two to configure your device.
-    
-    - OGUI can be opened with :material-microsoft-xbox:/:material-sony-playstation:/:material-steam: + :material-gamepad-circle-right: or double tapping/long pressing :material-microsoft-xbox-controller-menu:. How this is mapped will depend on your device.
-    
+
+    !!! info "See how to open OGUI [here](#how-do-i-open-the-ogui-overlay)."
+
     > [These devices](https://github.com/ublue-os/bazzite/blob/main/system_files/desktop/shared/usr/libexec/hwsupport/powerstation-hardware) will use this method by default.
   
 === "Decky Plugins"
 
-    You may also use Decky Plugins to configure TDP for your device if both Steam QAM and OGUI do not provide them. However, note that these plugins will interfere and conflict if you have multiple plugins turned on. Make sure you only have one means of TDP Control(including OGUI/PowerStation) running!
+    You may also use Decky Plugins to configure TDP for your device if both Steam QAM and OGUI do not provide them. However, note that these plugins will interfere and conflict if you have multiple plugins turned on. 
+    
+    !!! tip "Make sure you only have one means of TDP Control(including OGUI/PowerStation) running!"
     
     - [SimpleDeckyTDP](https://github.com/aarron-lee/SimpleDeckyTDP) plugin supports TDP, GPU, Power Governor, amongst other settings.
       - A [graphical application](https://github.com/aarron-lee/SimpleDeckyTDP-Desktop) is available, but needs to be manually installed.
@@ -89,23 +80,54 @@ There are a few options for TDP Controls that work with Bazzite:
 
 ![Overlay|690x431, 75%](/img/OGUI_Overlay.jpg)
 
-OGUI can be opened with :material-microsoft-xbox:/:material-sony-playstation:/:material-steam: + :material-gamepad-circle-right: or double tapping/long pressing :material-microsoft-xbox-controller-menu:. How this is mapped may depend on your device.
+The button to open OGUI varies on a device-by-device basis. <small>_We tried our best to find similar looking graphics on here..._</small>
+
+| Device | Graphic | Button Name | Action |
+| :-: | :-: | :- | :- |
+| ROG Ally series | :material-microsoft-dynamics-365:/:simple-nucleo:/:material-bookshelf: | Armory Crate Button | Long press |
+| MSI | :simple-wattpad: | Center M Button |  Long press |
+| Ayaneo | **. . .** | RC Button | press |
+| OneXPlayer | :simple-atlasos: | Guide Button | Hold Guide and press QAM |
+| Other Devices | :material-microsoft-xbox:/:material-sony-playstation:/:material-steam: + :material-gamepad-circle-right: | Guide + B | Single press |
 
 !!! note "OGUI is currently selectively enabled for devices in an allowlist and is not currently intended to be used with HTPC setups. If you have a handheld on which OGUI is not appearing, please open an issue on Github!"
 
-> You may see 
+> Instructions for enabling OGUI on unsupported devices are available [here](./Other_Handhelds/#enabling-ogui-on-unsupported-devices). Enable **at your own risk**.
+
+---
+
+### How do I open the QAM?
+
+ The button to open QAM varies on a device-by-device basis. <small>_We tried our best to find similar looking graphics on here..._</small>
+
+| Device | Graphic | Button Name | Action |
+| :-: | :-: | :- | :- |
+| ROG Ally series | :material-microsoft-dynamics-365:/:simple-nucleo:/:material-bookshelf: | Armory Crate Button | Single press |
+| Legion Go series | :material-tune-variant: | Legion Right Button | Single press |
+| MSI | :simple-wattpad: | Center M Button | Single press |
+| Ayaneo | _**//**_ | = Custom Function Key | Single press |
+| OneXPlayer | `TURBO` | Turbo Button | Single press |
+| GPD | :material-microsoft-xbox-controller-menu:/:octicons-home-24: | Menu Button / Home Button. | Long press :material-microsoft-xbox-controller-menu: if only :material-microsoft-xbox-controller-menu: is present, otherwise single press whichever is on the right side. |
+
+Alternatively, The Quick Access Menu is also accessible from the keyboard with <kbd>Ctrl</kbd> + <kbd>2</kbd>.
 
 ---
 
 ## Controller Information
 
-For most handheld hardware, besides the Steam Deck, emulation of a DualSense controller is used for full functionality. Double tap/hold :material-microsoft-xbox-controller-menu: to open the QAM and access settings for controller emulation.
+For most handheld hardware, besides the Steam Deck, emulation of a DualSense controller is used for full functionality. You may open the QAM or OGUI to access settings for controller emulation.
+
+!!! info "See how to open QAM [here](#how-do-i-open-the-qam)."
 
 !!! warning "Emulating an Xbox controller will cause reduced or missing functions."
+
+!!! note "If you experience Gyro issues, try setting controller emulation target in OGUI to **deck-uhid**. Device RGB functions can be controlled via the **Huesync Decky Plugin**."
 
 If your device has paddles, you will want to use the DualSense Edge or Steam Deck controller (**excluding the Ayn Loki**). It’s disabled by default because some games do not map it correctly.
 
 Some games and emulators may need Steam Input to be **disabled** to work correctly with your controls.
+
+---
 
 ### Desktop Controls
 
@@ -113,9 +135,15 @@ Some games and emulators may need Steam Input to be **disabled** to work correct
 
 Desktop controller layout may not exist by default if Steam doesn't setup your handheld controller properly. This can be fixed in Steam's controller settings.
 
-The virtual keyboard is provided by Steam's on-screen keyboard, which requires setup in Desktop Mode. There is **no default keybinding for Steam's on-screen keyboard**, so it needs to be remapped to <kbd>X</kbd> or any key of your preference. 
+The virtual keyboard is provided by Steam's on-screen keyboard, which requires setup in Desktop Mode. There is **no default keybinding for Steam's on-screen keyboard**, so it will need remapping to any key of your preference, though :material-gamepad-circle-left: is generally recommended. 
+
+!!! tip "You may set up OSK under **Steam → Settings → Controller → Desktop Layout**."
 
 The desktop controller layout may not exist by default if Steam doesn't setup your handheld controller properly. This can be fixed in Steam's controller settings.
+
+!!! info "A feature to control the desktop using a controller was added in KDE Plasma 6.7. This feature conflicts with Steam's emulation method, so make sure you disable it, or vice versa should you want to use Plasma's native controller support."
+
+> See [here](/General/issues_and_resolutions/#gamepads-and-handheld-joysticks-dont-work-in-desktop-mode) for more details.
 
 ---
 
@@ -127,9 +155,9 @@ To install [Decky Loader](https://decky.xyz), open a host terminal and enter:
 ujust setup-decky
 ```
 
-You can access Decky Loader by pressing :material-microsoft-xbox-controller-menu: once to open the QAM from within Steam Gaming Mode or Steam Big Picture Mode.
+You can access Decky Loader inside the QAM from within Steam Gaming Mode or Steam Big Picture Mode.
 
-Alternatively, The Quick Access Menu is accessible from the keyboard with Control + 2, or with an external controller by pressing :material-microsoft-xbox:/:material-sony-playstation:/:material-steam: + :material-gamepad-circle-down:
+!!! info "See how to open QAM [here](#how-do-i-open-the-qam)."
 
 ### Decky Plugins
 
@@ -153,7 +181,7 @@ Your mileage may vary with untested hardware. Bazzite does **not** automatically
 
     You may also submit PRs to get your device officially supported on Bazzite if you feel like it is in a good state with Linux support.
 
-> Instructions for enabling OGUI on unsupported Handhelds are available [here](./Other_Handhelds/#enabling-ogui-on-unsupported-devices)
+> Instructions for enabling OGUI on unsupported Handhelds are available [here](./Other_Handhelds/#enabling-ogui-on-unsupported-devices).
 
 ---
 

--- a/src/Handheld_and_HTPC_edition/Handheld_Wiki/index.md
+++ b/src/Handheld_and_HTPC_edition/Handheld_Wiki/index.md
@@ -1,8 +1,10 @@
 ---
-title: Handheld Compatibility
+title: Handheld Wiki
 ---
 
-# Handheld Compatibility
+# Handheld Wiki
+
+> This is a more general guide. For troubleshooting, see [Steam Gaming Mode Quirks](/Handheld_and_HTPC_edition/quirks.md).
 
 ## SteamOS-like Functionality
 
@@ -39,7 +41,7 @@ _Click the name of each hardware to view post-installation setup, known working 
 
 There are a few options for TDP Controls that work with Bazzite:
 
-!!! info "If you open OpenGamepadUI and see the message `Waiting for PowerStation service...`, this means your device does not use PowerStation for TDP. This is completely normal and can be safely ignored."
+!!! info "If you open OpenGamepadUI and see the message `TDP managed by Steam`, this means your device's TDP is in fact managed by Steam."
 
 !!! tip "If detailed TDP configurations cannot be found, try selecting the **Performance** profile → scroll down and enable TDP and GPU Clocks. This should enable detailed TDP configuration in Watts."
 
@@ -84,13 +86,16 @@ The button to open OGUI varies on a device-by-device basis. <small>_We tried our
 
 | Device | Graphic | Button Name | Action |
 | :-: | :-: | :- | :- |
-| ROG Ally series | :material-microsoft-dynamics-365:/:simple-nucleo:/:material-bookshelf: | Armory Crate Button | Long press |
+| ROG Ally series | :material-microsoft-dynamics-365:/:simple-nucleo: | Armory Crate Button | Long press |
+| Xbox Ally series | :material-bookshelf:/<kbd>\|\|\\</kbd> | Library Button | Long press |
 | MSI | :simple-wattpad: | Center M Button |  Long press |
-| Ayaneo | **. . .** | RC Button | press |
+| Ayaneo | **. . .** | RC Button | Press |
 | OneXPlayer | :simple-atlasos: | Guide Button | Hold Guide and press QAM |
 | Other Devices | :material-microsoft-xbox:/:material-sony-playstation:/:material-steam: + :material-gamepad-circle-right: | Guide + B | Single press |
 
 !!! note "OGUI is currently selectively enabled for devices in an allowlist and is not currently intended to be used with HTPC setups. If you have a handheld on which OGUI is not appearing, please open an issue on Github!"
+
+!!! tip ":material-microsoft-xbox:/:material-sony-playstation:/:material-steam: + :material-gamepad-circle-right: (Guide + B) is always a fallback that can be used"
 
 > Instructions for enabling OGUI on unsupported devices are available [here](./Other_Handhelds/#enabling-ogui-on-unsupported-devices). Enable **at your own risk**.
 
@@ -102,7 +107,8 @@ The button to open OGUI varies on a device-by-device basis. <small>_We tried our
 
 | Device | Graphic | Button Name | Action |
 | :-: | :-: | :- | :- |
-| ROG Ally series | :material-microsoft-dynamics-365:/:simple-nucleo:/:material-bookshelf: | Armory Crate Button | Single press |
+| ROG Ally series | :material-microsoft-dynamics-365:/:simple-nucleo: | Armory Crate Button | Single press |
+| Xbox Ally series | :material-bookshelf:/<kbd>\|\|\\</kbd> | Library Button | Single press |
 | Legion Go series | :material-tune-variant: | Legion Right Button | Single press |
 | MSI | :simple-wattpad: | Center M Button | Single press |
 | Ayaneo | _**//**_ | = Custom Function Key | Single press |

--- a/src/Handheld_and_HTPC_edition/index.zh_CN.md
+++ b/src/Handheld_and_HTPC_edition/index.zh_CN.md
@@ -1,0 +1,17 @@
+---
+title: Bazzite 掌机版指南
+---
+
+# Bazzite 掌机版指南
+
+- [**Bazzite 掌机版概览**](/Handheld_and_HTPC_edition/Steam_Gaming_Mode.md)
+- [**Steam 游戏模式常见问题和解决方法**](/Handheld_and_HTPC_edition/quirks.md)
+- [**掌机兼容性**](/Handheld_and_HTPC_edition/Handheld_Wiki/index.md)
+  - [**ASUS 掌机**](/Handheld_and_HTPC_edition/Handheld_Wiki/ASUS_ROG_Ally.md)
+  - [**Lenovo 掌机**](/Handheld_and_HTPC_edition/Handheld_Wiki/Lenovo_Legion_Go.md)
+  - [**GPD 掌机**](/Handheld_and_HTPC_edition/Handheld_Wiki/GPD_Handhelds.md)
+  - [**OneXPlayer 掌机**](/Handheld_and_HTPC_edition/Handheld_Wiki/OneXPlayer_Handhelds.md)
+  - [**Ayn 掌机**](/Handheld_and_HTPC_edition/Handheld_Wiki/Ayn_Handhelds.md)
+  - [**Ayaneo 掌机**](/Handheld_and_HTPC_edition/Handheld_Wiki/Ayaneo_Handhelds.md)
+  - [**Steam Deck**](/Handheld_and_HTPC_edition/Handheld_Wiki/Steam_Deck.md)
+  - [**其他掌机**](/Handheld_and_HTPC_edition/Handheld_Wiki/Other_Handhelds.md)

--- a/src/Handheld_and_HTPC_edition/quirks.md
+++ b/src/Handheld_and_HTPC_edition/quirks.md
@@ -4,308 +4,38 @@ title: Steam Gaming Mode Quirks and Workarounds
 
 # Steam Gaming Mode Quirks and Workarounds
 
----
+> For a more general guide, see [Handheld Wiki](/Handheld_and_HTPC_edition/Handheld_Wiki).
 
-## Fan Control Functionality is Missing
+## Index
 
-[Bazzite Deck 44](https://universal-blue.discourse.group/t/bazzites-biggest-update-deck-44-has-launched-happy-birthday-to-universal-blue/12373) brings along a major change in our handheld stack. With this new stack, some devices may no longer allow fan control, but a plugin for OGUI is in development to restore them. If you are affected, let us know on our GitHub and we will update you as this lands.
-
----
-
-## TDP Controls are Missing
-
-> See [Handheld Wiki](/Handheld_and_HTPC_edition/Handheld_Wiki/#tdp-controls).
-
----
-
-## My Gamepad Menu is Missing
-
-!!! info "OpenGamepadUI is disabled by default for the Steam Deck and HTPCs."
-
-Bazzite uses an allowlist to selectively enable OpenGamepadUI for handhelds that are known to require it to enable built-in joysticks and bumpers. Enabling OpenGamepadUI on devices that don't require them may lead to unexpected issues.
-
-Nevertheless, you can toggle OpenGamepadUI using the following command:
-
-```bash
-ujust configure-opengamepadui
-```
-
-> You can check the allowlist [here](https://github.com/ublue-os/bazzite/blob/main/system_files/desktop/shared/usr/libexec/hwsupport/steamos-manager-hardware). Additionally, a list of non-Valve handhelds that need PowerStation for TDP control are available [here](https://github.com/ublue-os/bazzite/blob/main/system_files/desktop/shared/usr/libexec/hwsupport/powerstation-hardware).
+- [Boot and Startup Issues](#1-boot-and-startup-issues)
+- [Display and Video Output](#2-display-and-video-output)
+- [Audio Issues](#3-audio-issues)
+- [Input, Keyboard, and Controllers](#4-input-keyboard-and-controllers)
+- [Performance, Power, and Hardware](#5-performance-power-and-hardware)
+- [Decky Loader, OGUI, and Add‑ons](#6-decky-loader-ogui-and-addons)
+- [Storage and Filesystem](#7-storage-and-file-system)
+- [Miscellaneous](#8-miscellaneous)
 
 ---
 
-## How do I use my microSD card that I used on my Steam Deck running SteamOS?
+## 1. Boot and Startup Issues
 
-Open a host terminal and enter this **command**:
-
-```bash
-ujust switch-to-ext4
-```
-
----
-
-## How do I specify the correct monitor for Gaming Mode to use? (HTPC only)
-
-In Desktop Mode, open a host terminal and run the following **command** to find your Display Output Name:
-
-=== "KDE"
-
-    ```bash
-    kscreen-doctor -o
-    ```
-
-=== "GNOME"
-
-    ```bash
-    gnome-randr
-    ```
-    !!! note
-
-        It has been reported that some systems don't properly report the Display Output Name when using gnome-randr. You may run the command below to list the names of all connected outputs without any details, and compare them with the previous command output to find your actual Display Output Name.
-    
-        ```bash
-        grep -r '^connected' /sys/class/drm/*/status | grep -Po 'card.?-\K([^/]*)'
-        ```
-After finding the correct Display Output Name, you may now create a file to tell Steam Gaming Mode to use your display.
-
-=== "Using the GUI"
-    
-    In Desktop Mode or Nested Desktop, 
-    
-    1. Create the directory `~/.config/environment.d` if it does not exist already.
-    
-    2. Create the file under the aforementioned directory named `10-gamescope-session.conf` if it does not exist already.
-
-    3. Add the following line to the file:
-        `OUTPUT_CONNECTOR=DP-1`
-    !!! info "Make sure you change `DP-1` to your Display Output!"
-    
-    4. Save the file, restart, and verify that your device is outputing on the correct display.
-    
-=== "Using the command line"
-    
-    Run the following commands to create the file:
-    
-    !!! info "Make sure you change `DP-1` to your Display Output!"
-    
-    ```bash
-    mkdir -p ~/.config/environment.d
-    echo "OUTPUT_CONNECTOR=DP-1" >> ~/.config/environment.d/10-gamescope-session.conf
-    ```
-
----
-
-## Audio output not working (Default Device)
-
-This issue happens usually with HDMI TV audio. Enter Desktop Mode and in system settings, disable devices that do not match the sound output that you are using. 
-
-!!! info "A typical fix is disabling everything except HDMI for your TV audio."
-
----
-
-## Change physical keyboard layout for Steam Gaming Mode
-
-Steam Gaming Mode has no official way to change the physical keyboard layout and defaults to the US layout. If you want to change the layout, then you may set it globally through an environment variable.
-
-=== "Using the GUI"
-    
-    In Desktop Mode or Nested Desktop, 
-    
-    1. Create the directory `~/.config/environment.d` if it does not exist already.
-    
-    2. Create the file under the aforementioned directory named `10-gamescope-session.conf` if it does not exist already.
-
-    3. Add the following line to the file, replacing `us` with the correct layout.
-        `XKB_DEFAULT_LAYOUT=us`
-    !!! info 
-    
-        The layout name is usually a [2-letter country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements),
-        Alternatively, you may use one of the following commands to see a list without a description:
-
-        -   `localectl list-x11-keymap-models`
-        -   `localectl list-x11-keymap-layouts`
-        -   `localectl list-x11-keymap-variants [layout]`
-        -   `localectl list-x11-keymap-options`
-    
-    4. Save the file, restart, and verify that you have the correct keyboard layout.
-    
-=== "Using the command line"
-    
-    Run the following commands to create the file, replacing `us` with the correct layout.:
-    
-    ```bash
-    mkdir -p ~/.config/environment.d
-    echo "XKB_DEFAULT_LAYOUT=us" >> ~/.config/environment.d/10-gamescope-session.conf
-    ```
-    
-    !!! info 
-    
-        The layout name is usually a [2-letter country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements),
-        Alternatively, you may use one of the following commands to see a list without a description:
-
-        -   `localectl list-x11-keymap-models`
-        -   `localectl list-x11-keymap-layouts`
-        -   `localectl list-x11-keymap-variants [layout]`
-        -   `localectl list-x11-keymap-options`
-
-!!! note 
-
-    This fix will also work in Desktop Mode, including when running Nested Gamescope or when using Nested Desktop, but it has its own quirks: 
-    
-    -   <kbd>altgr</kbd> + <kbd>2</kbd> to write `@` on the Norwegian layout will still not work, though the basic keyboard layout does work. Fortunately, The <kbd>altgr</kbd> key is not needed for normal typing on the Norwegian layout. 
-    -   The <kbd>altgr</kbd> key has been reported to work on the French layout
-    -   Your mileage may vary on differing keyboard layouts.
-
----
-
-## How do I disable certain "Steam Deck" features that conflict with my setup?
-
-**Scenarios where this is desirable**:
-
-- Keyboard and mouse does not work for a certain game
-
-- The game’s launcher for adjusting video settings or adding mods does not launch
-
-- Certain features/graphics options are not available
-
-Open the game's properties on Steam and [**add this launch option**](/Gaming/launch-options-env-variables/#where-to-set-launch-options):
-
-```bash
-sd0 %command%
-```
-> Read more about Launch Options and Environment Variables [here](/Gaming/launch-options-env-variables/)
-
----
-
-## Why do specific Decky Loader plugins not function on Bazzite?
-
-Some plugins are built specifically for SteamOS or the Steam Deck, and won’t necessarily work on Bazzite or non-Steam-Deck hardware.
-
-- For example, the [DeckMTP plugin](https://github.com/dafta/DeckMTP) only works on the Steam Deck models and will not work on other hardware.
-
----
-
-## How do I use SteamDeckGyroDSU on hardware that isn't the Steam Deck?
-
-You typically cannot use SteamDeckGyroDSU outside of the Steam Deck, though you may try disabling Steam Input and it _may_ work depending on your hardware and use case.
-
----
-
-## How do I specify which GPU that Steam Gaming Mode should use?
-
-Open a TTY session with an **external physical keyboard** using this **keyboard combination**: <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F4</kbd>
-
-!!! info "This feature is superceded by the new [CardWire](https://github.com/OpenGamingCollective/cardwire) GPU Manager in Bazzite-Deck 44."
-   
-```bash
-export-gpu
-```
-
----
-
-## I lost my "Return to Gaming Mode" shortcut
-
-You can restore this shortcut by opening terminal and running:
-
-```bash
-ujust restore-gamemode-shortcut
-```
-
----
-
-## Black Screen When Booting into Gaming Mode
+### Black Screen When Booting into Gaming Mode
 
 If you: 
 
--   Encounter a black screen after the Bazzite spinner, 
--   Does not have Internet connection,
--   find that it is obvious that Steam is trying and failing to update due to the lack of/ slow Internet;
+- Encounter a black screen after the Bazzite spinner, 
+- Does not have Internet connection,
+- find that it is obvious that Steam is trying and failing to update due to the lack of/ slow Internet;
 
-You may follow the instructions [here](#i-cannot-progress-past-this-screen) to boot into Desktop Mode.
-
----
- 
-## I cannot progress past this screen
-
-!!! info "The instructions below are also applicable for [Black Screen When Booting into Gaming Mode](#black-screen-when-booting-into-gaming-mode)."
-
-![If your controller supports Bluetooth, select Next to pair to your Steam Machine.](../img/connect_controller.jpg)
-
-1. Open a TTY session with an **external physical keyboard** using this **keyboard combination**:
-    <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F4</kbd>
-2. Login to your user.
-3. Enter this command:
-```bash
-steamosctl switch-to-desktop-mode
-```
-4. Log into Steam in Desktop mode, and reboot the device.
+You may follow the instructions [here](#unable-to-progress-past-controller-screen) to boot into Desktop Mode.
 
 ---
 
-## Stuck on 'Update calculating: Time Remaining'
+### Stuck at Bazzite Logo
 
-![Update time remaining](../img/update_calculating_time_remaining.jpg)
-
-Reboot the device.
-
----
-
-## Steam broke and Gaming Mode is broken too
-
-In scenarios where Steam Gaming Mode refuses to start due to an issue with the Steam client:
-
-Follow the instructions [here](#stuck-at-the-bazzite-logo).
-
----
-
-## "Something went wrong while displaying this content" Error
-
-This is most likely due to a broken Decky Loader plugin you have installed and can be fixed by uninstalling the broken plugin. 
-
-!!! note "Specific CSS Loader themes may also cause this issue."
-
----
-
-## Why is VRR not working on my VRR-compatible display?
-
-!!! info "Support for HDMI 2.1 FRL, VRR, and DSC on AMD Graphics cards are added in Linux Kernel version 7.2. [Update to the newest version of Bazzite](/Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/updating_guide) to use this feature!"
-
-Enable it in **Bazzite Portal → Tweak Systems → Enable HDMI 2.1 for AMD Graphics Cards**. 
-
-!!! note "This may cause flickering and instability on some displays."
-
-> You may read more about it [here](https://www.phoronix.com/news/HDMI-2.1-OSS-Rejected).
-
----
-
-## Fixing Flickering and Instability in Some Displays
-
-This is due to an issue in how AMD graphics cards change power states. This issue has been reported upstream to be fixed.
-
-You may use the following workarounds to remediate this issue.
-
-1. Turn on VRR in Steam Gaming Mode at all times.
-2. Set the refresh rate in Desktop Mode to 60hz and set **Adaptive Sync** to **Never** or **Always**.
-
-Alternatively, you may use LACT to set your card to max power and save it as your default profile until the issue is resolved.
-
-> If you'd like to help report this bug, you may do so [here](https://gitlab.freedesktop.org/drm/amd/-/work_items/5649).
-
----
-
-## Rainbow Display
-
-![My-Eyes|690x430](../img/hdr-woes.png)
-
-Toggle HDR on and off in the Quick Access Menu.
-
-!!! note "You may need to additionally enable the "Force Composite" option found in the Developer Options, of which [Developer Options] also has to be enabled in the Steam settings beforehand."
-
----
-
-## Stuck at the Bazzite logo
-
-!!! info "The instructions below are also applicable for [Steam broke and Gaming Mode is broken too](#steam-broke-and-gaming-mode-is-broken-too)."
+!!! info "The instructions below are also applicable for [Steam and Gaming Mode are broken](/Handheld_and_HTPC_edition/quirks/#steam-and-steam-gaming-mode-are-broken)."
 
 === "Desktop Mode Method"
 
@@ -344,15 +74,326 @@ Toggle HDR on and off in the Quick Access Menu.
     3.   You can move your games from the renamed `Steam.bak` directory to the new `Steam` directory if you had any installed previously on your internal storage.
     4.  You may use <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F2</kbd> to exit the TTY.
 
-> You may also follow the video guide below：
+> You may also follow the video guide below:
 https://www.youtube.com/watch?v=gE1ff72g2Gk
 
 ---
 
-## Nvidia GPU Exclusive Issues with Steam Gaming Mode
+### Stuck on 'Update calculating: Time Remaining'
+
+![Update time remaining](../img/update_calculating_time_remaining.jpg)
+
+Reboot the device.
+
+---
+
+### Steam and Steam Gaming Mode Are Broken
+
+In scenarios where Steam Gaming Mode refuses to start due to an issue with the Steam client:
+
+Follow the instructions [here](#stuck-at-bazzite-logo).
+
+---
+
+### Unable to Progress Past Controller Screen
+
+!!! info "The instructions below are also applicable for [Black Screen When Booting into Gaming Mode](#black-screen-when-booting-into-gaming-mode)."
+
+![If your controller supports Bluetooth, select Next to pair to your Steam Machine.](../img/connect_controller.jpg)
+
+1. Open a TTY session with an **external physical keyboard** using this **keyboard combination**:
+    <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F4</kbd>
+2. Login to your user.
+3. Enter this command:
+```bash
+steamosctl switch-to-desktop-mode
+```
+4. Log into Steam in Desktop mode, and reboot the device.
+
+---
+
+## 2. Display and Video Output
+
+### Flickering and Instability on Some Displays
+
+This is due to an issue in how AMD graphics cards change power states. This issue has been reported upstream to be fixed.
+
+You may use the following workarounds to remediate this issue.
+
+1. Turn on VRR in Steam Gaming Mode at all times.
+2. Set the refresh rate in Desktop Mode to 60hz and set **Adaptive Sync** to **Never** or **Always**.
+
+Alternatively, you may use LACT to set your card to max power and save it as your default profile until the issue is resolved.
+
+> If you'd like to help report this bug, you may do so [here](https://gitlab.freedesktop.org/drm/amd/-/work_items/5649).
+
+---
+
+### Rainbow Display
+
+![My-Eyes|690x430](../img/hdr-woes.png)
+
+Toggle HDR on and off in the Quick Access Menu.
+
+??? note "You may need to additionally enable the **"Force Composite"** option found in the Developer Options."
+
+    This can be enabled by:
+
+    1. Steam Settings → System → **Enable Developer Mode**
+    2. Steam Settings → Developer → Check **Force Composite**
+
+---
+
+### VRR Not Working on VRR-Compatible Displays
+
+!!! info "Support for HDMI 2.1 FRL, VRR, and DSC on AMD Graphics cards are added in Linux Kernel version 7.2. [Update to the newest version of Bazzite](/Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/updating_guide) to use this feature!"
+
+Enable it in **Bazzite Portal → Tweak Systems → Enable HDMI 2.1 for AMD Graphics Cards**. 
+
+!!! note "This may cause flickering and instability on some displays."
+
+> You may read more about it [here](https://www.phoronix.com/news/HDMI-2.1-OSS-Rejected).
+
+---
+
+### Nvidia GPU Exclusive Issues with Steam Gaming Mode
 
 - "Enable GPU accelerated rendering in web views (requires restart)" must be enabled in the Steam settings for better performance in the UI.
   - Enabling this option will most likely cause game-breaking graphical artifacts.
 - HDR can cause game-breaking graphical artifacts.
+
+---
+
+### Specifying Correct Monitor for Gaming Mode (HTPC only)
+
+In Desktop Mode, open a host terminal and run the following **command** to find your Display Output Name:
+
+=== "KDE"
+
+    ```bash
+    kscreen-doctor -o
+    ```
+
+=== "GNOME"
+
+    ```bash
+    gnome-randr
+    ```
+    !!! note
+
+        It has been reported that some systems may not properly report the Display Output Name when using `gnome-randr`. You may run the command below to list the names of all connected outputs without any details, and compare them with the previous command output to find your actual Display Output Name.
+    
+        ```bash
+        grep -r '^connected' /sys/class/drm/*/status | grep -Po 'card.?-\K([^/]*)'
+        ```
+
+After finding the correct Display Output Name, you may now create a file to tell Steam Gaming Mode to use your display.
+
+=== "Using the GUI"
+    
+    In Desktop Mode or Nested Desktop, 
+    
+    1. Create the directory `~/.config/environment.d` if it does not exist already.
+    
+    2. Create the file under the aforementioned directory named `10-gamescope-session.conf` if it does not exist already.
+
+    3. Add the following line to the file:
+        `OUTPUT_CONNECTOR=DP-1`
+    !!! info "Make sure you change `DP-1` to your Display Output!"
+    
+    4. Save the file, restart, and verify that your device is outputing on the correct display.
+    
+=== "Using the command line"
+    
+    Run the following commands to create the file:
+    
+    !!! info "Make sure you change `DP-1` to your Display Output!"
+    
+    ```bash
+    mkdir -p ~/.config/environment.d
+    echo "OUTPUT_CONNECTOR=DP-1" >> ~/.config/environment.d/10-gamescope-session.conf
+    ```
+
+---
+
+## 3. Audio Issues
+
+### Audio Output Not Working (Default Device)
+
+This issue happens usually with HDMI TV audio. Enter Desktop Mode and in **System Settings**, disable devices that do not match the sound output that you are using. 
+
+!!! info "A typical fix is disabling everything except HDMI for your TV audio."
+
+---
+
+## 4. Input, Keyboard, and Controllers
+
+### Change Physical Keyboard Layout for Steam Gaming Mode
+
+Steam Gaming Mode has no official way to change the physical keyboard layout and defaults to the US layout. If you want to change the layout, then you may set it globally through an environment variable.
+
+=== "Using the GUI"
+    
+    In Desktop Mode or Nested Desktop, 
+    
+    1. Create the directory `~/.config/environment.d` if it does not exist already.
+    
+    2. Create the file under the aforementioned directory named `10-gamescope-session.conf` if it does not exist already.
+
+    3. Add the following line to the file, replacing `us` with the correct layout.
+        ```console
+        XKB_DEFAULT_LAYOUT=us
+        ```
+    4. Save the file, restart, and verify that you have the correct keyboard layout.
+    
+=== "Using the command line"
+    
+    Run the following commands to create the file, replacing `us` with the correct layout.:
+    
+    ```bash
+    mkdir -p ~/.config/environment.d
+    echo "XKB_DEFAULT_LAYOUT=us" >> ~/.config/environment.d/10-gamescope-session.conf
+    ```
+    
+!!! info 
+
+    The layout name is usually a [2-letter country code](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements),
+    Alternatively, you may use one of the following commands to see a list without a description:
+
+    -   `localectl list-x11-keymap-models`
+    -   `localectl list-x11-keymap-layouts`
+    -   `localectl list-x11-keymap-variants [layout]`
+    -   `localectl list-x11-keymap-options`
+
+!!! note 
+
+    This fix will also work in Desktop Mode, including when running Nested Gamescope or when using Nested Desktop, but it has its own quirks: 
+    
+    -   <kbd>altgr</kbd> + <kbd>2</kbd> to write `@` on the Norwegian layout will still not work, though the basic keyboard layout does work. Fortunately, The <kbd>altgr</kbd> key is not needed for normal typing on the Norwegian layout. 
+    -   The <kbd>altgr</kbd> key has been reported to work on the French layout
+    -   Your mileage may vary on differing keyboard layouts.
+
+---
+
+### Use SteamDeckGyroDSU on Non-Steam Deck Hardware
+
+You typically cannot use SteamDeckGyroDSU outside of the Steam Deck, though you may try disabling Steam Input and it _may_ work depending on your hardware and use case.
+
+---
+
+### Disabling Certain "Steam Deck" Features
+
+**Scenarios where this is desirable**:
+
+- Keyboard and mouse does not work for a certain game
+- The game’s launcher for adjusting video settings or adding mods does not launch
+- Certain features/graphics options are not available
+
+Open the game's properties on Steam and [**add this launch option**](/Gaming/launch-options-env-variables/#where-to-set-launch-options):
+
+```bash
+sd0 %command%
+```
+> Read more about Launch Options and Environment Variables [here](/Gaming/launch-options-env-variables/)
+
+---
+
+## 5. Performance, Power, and Hardware
+
+### Fan Control Functionality Missing
+
+[Bazzite Deck 44](https://universal-blue.discourse.group/t/bazzites-biggest-update-deck-44-has-launched-happy-birthday-to-universal-blue/12373) brings along a major change in our handheld stack. With this new stack, some devices may no longer allow fan control, but a plugin for OGUI is in development to restore them. If you are affected, let us know on our GitHub and we will update you as this lands.
+
+---
+
+### TDP Controls Missing
+
+> See [Handheld Wiki](/Handheld_and_HTPC_edition/Handheld_Wiki/#tdp-controls).
+
+---
+
+### Specifying Steam Gaming Mode GPU Usage
+
+Open a TTY session with an **external physical keyboard** using this **keyboard combination**: <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>F4</kbd>
+
+!!! info "This feature is superceded by the new [CardWire](https://github.com/OpenGamingCollective/cardwire) GPU Manager in Bazzite-Deck 44."
+   
+```bash
+export-gpu
+```
+
+---
+
+### Wi-Fi Is Slow / Wi-Fi Lag Spikes
+
+The Wi-Fi power saving feature in Linux may work poorly on some devices. If the problem is not present in Windows, you may try the solution below.
+
+!!! info "This section is for devices running the `-deck` images. For desktop images, see [here](/General/issues_and_resolutions/#wi-fi-is-slow-wi-fi-lag-spikes)."
+
+If you are using Steam Gaming Mode (i.e. not booting straight into a desktop environment like KDE or GNOME), try:
+
+1. Steam Settings → System → Enable Developer Mode
+2. Steam Settings → Developer → Uncheck **Enable Wi-Fi Power Management**
+3. Reboot
+
+---
+
+## 6. Decky Loader, OGUI, and Add‑ons
+
+### Decky Loader Plugins Not Functioning
+
+Some plugins are built specifically for SteamOS or the Steam Deck, and won’t necessarily work on Bazzite or non-Steam-Deck hardware.
+
+- For example, the [DeckMTP plugin](https://github.com/dafta/DeckMTP) only works on the Steam Deck models and will not work on other hardware.
+
+---
+
+### Missing Gamepad Menu
+
+!!! tip "See [Handheld Wiki](/Handheld_and_HTPC_edition/Handheld_Wiki/#how-do-i-open-the-ogui-overlay) if you cannot find how to open the OGUI menu on supported devices."
+
+!!! info "OpenGamepadUI is disabled by default for the Steam Deck and HTPCs."
+
+Bazzite uses an allowlist to selectively enable OpenGamepadUI for handhelds that are known to require it to enable built-in joysticks and bumpers. Enabling OpenGamepadUI on devices that don't require them may lead to unexpected issues.
+
+Nevertheless, you can toggle OpenGamepadUI using the following command:
+
+```bash
+ujust configure-opengamepadui
+```
+
+> You can check the allowlist [here](https://github.com/ublue-os/bazzite/blob/main/system_files/desktop/shared/usr/libexec/hwsupport/steamos-manager-hardware). Additionally, a list of non-Valve handhelds that need PowerStation for TDP control are available [here](https://github.com/ublue-os/bazzite/blob/main/system_files/desktop/shared/usr/libexec/hwsupport/powerstation-hardware).
+
+---
+
+### "Something went wrong while displaying this content" Error
+
+This is most likely due to a broken Decky Loader plugin you have installed and can be fixed by uninstalling the broken plugin. 
+
+!!! note "Specific CSS Loader themes may also cause this issue."
+
+---
+
+## 7. Storage and File System
+
+### Using a MicroSD Card That Was Previously Used on a Steam Deck Running SteamOS
+
+Open a host terminal and enter this **command**:
+
+```bash
+ujust switch-to-ext4
+```
+
+---
+
+## 8. Miscellaneous
+
+### "Return to Gaming Mode" Shortcut Missing
+
+You can restore this shortcut by opening terminal and running:
+
+```bash
+ujust restore-gamemode-shortcut
+```
 
 ---

--- a/src/Installing_and_Managing_Software/Homebrew.md
+++ b/src/Installing_and_Managing_Software/Homebrew.md
@@ -30,6 +30,27 @@ brew install <package>
 
 The [Bold Brew application](https://bold-brew.com/) offers a terminal user interface (TUI) for installing common Homebrew packages.
 
+## Fonts
+
+Homebrew is also used for installing fonts, browse [this page](https://formulae.brew.sh/cask-font/) and install your favorite fonts. They will be copied into `~/.local/share/fonts`
+
+- Microsoft Fonts:
+
+If you need to install Microsoft fonts in order to ensure compatibility with some documents, most of them are in Homebrew.
+
+Be aware that some of these fonts are copyrighted by Microsoft.
+Microsoft UK confirmed you are allowed to have them, provided that you own a copy of either:
+
+- Microsoft PowerPoint Viewer (free, retired)
+- May include PowerPoint Mobile (free)
+- Microsoft Office (Any version, Windows or Mac)
+
+Calibri, Cambria, Candara, Consolas, Constantia and Corbel are included in font-microsoft-office, the others must be installed individually. You can install all of them at once by running the following command in a terminal:
+
+```
+brew tap colindean/fonts-nonfree && brew install --cask font-microsoft-office font-microsoft-aptos font-arial font-arial-black font-courier-new font-times-new-roman font-georgia
+```
+
 ## Project Website
 
 https://brew.sh/

--- a/src/Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/rebase_guide.md
+++ b/src/Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/rebase_guide.md
@@ -238,7 +238,7 @@ You may view the list of available stable builds by using the following methods:
 
 ### Rebasing to a Specific Build
 
-Rebasing to a specific build is as simple as using a **TAG** with a format of `VERSION-YEARMONTHDAY`
+Rebasing to a specific build is as simple as using a **TAG** with a format of `BRANCH-VERSION.YEARMONTHDAY`
 
 === "Bazzite Rollback Helper"
 
@@ -249,11 +249,18 @@ Rebasing to a specific build is as simple as using a **TAG** with a format of `V
     !!! example
         
         Rebasing to `bazzite-deck`'s (_Fedora 39_) build on **13th January, 2024**:
+        
         ```bash
-        brh rebase bazzite-deck:39-20240113
+        brh rebase bazzite-deck:stable-39.20240113
         ```
 
         <small>_(Please note that this build is no longer available since it is past the 90 day limit and is only used as an example for this documentation.)_</small>
+        
+        Rebasing to `bazzite-deck`'s newest Fedora 43 build, if you are already on `bazzite-deck`:
+        
+        ```bash
+        brh rebase stable-43
+        ```
 
 === "Backend Commands"
 

--- a/src/Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/rebase_guide.md
+++ b/src/Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/rebase_guide.md
@@ -146,6 +146,17 @@ The process of rebasing is very similar to updating(or rather the other way arou
     | Beta Candidate | `:unstable` |
     | Main | `:unstable` |
 
+!!! info
+
+    If you encounter the following message:
+    
+    ```console
+    error: Old and new refs are equal: ostree-image-signed:docker://ghcr.io/ublue-os/bazzite:testing
+    Rebase failed. Image may not exist or be accessible.
+    ```
+
+    This means the Image Flavor/Branch you are trying to rebase to is the same as the one you are currently on. Simply [update](/Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/updating_guide/) to receive the newest version of your current image.
+
 ---
 
 ## Differences between Update Branches

--- a/src/Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/rolling_back_system_updates.md
+++ b/src/Installing_and_Managing_Software/Updates_Rollbacks_and_Rebasing/rolling_back_system_updates.md
@@ -136,7 +136,9 @@ Flatpak applications can be easily managed and downgraded in Warehouse.
 
 Autologin will be broken when rolling back from Bazzite Deck 44 to Bazzite Deck 43.
 
-To fix this, simply delete `zz-steamos` and `zz-bazzite` under `/etc/sddm.conf.d/`
+To fix this, simply delete any files prefixed with `zz-` under `/etc/sddm.conf.d/`
+
+!!! tip "These typically include the following: `zz-steamos`, `zz-bazzite`, `zz-holo-autologin.conf`, `zz-bazzite-autologin.conf` and `zz-steamos-autologin.conf`"
 
 > Read more about Bazzite Deck 44 [here](https://universal-blue.discourse.group/t/bazzites-biggest-update-deck-44-has-launched-happy-birthday-to-universal-blue/12373). You may report any relevant regressions under [this Discord support thread](https://discord.com/channels/1072614816579063828/1539396706712555712).
 

--- a/src/Installing_and_Managing_Software/ujust.md
+++ b/src/Installing_and_Managing_Software/ujust.md
@@ -23,7 +23,6 @@ Open a host terminal and **enter this command**:
 ujust
 ```
 
-
 ![ujust TUI|690x403](../img/ujust_TUI.png)
 
 ```
@@ -62,7 +61,7 @@ ujust | grep "<search keyword(s)>"
 - `distrobox-`: Distrobox exclusive verb intended to make container usage easier.
 - `foo`: Replace this with whatever the command is called.
   - These are shortcuts that we have deemed necessary to not have a verb.
-    - **Examples**: `ujust update` & `ujust enroll-secureboot-key`
+    - **Examples**: `ujust update` & `ujust enroll-secureboot-key`.
 
 ## View each `ujust` script's source code
 
@@ -73,7 +72,7 @@ ujust --show <command>
 ```
 
 Alternatively, you can find the `ujust` commands locally in:
-`/usr/share/ublue-os/just`
+`/usr/share/ublue-os/just`.
 
 !!! note
 
@@ -85,32 +84,32 @@ These are just some of the common Bazzite `ujust` script examples, there are muc
 
 ### Maintenance Scripts
 
-- **ujust update** - updates system, flatpaks, and containers all at once
-- **ujust configure-grub** - Configures GRUB boot menu visibility
-- **ujust fix-reset-steam** - Reset the Steam folder back to a fresh state without removing games, music, saves, etc. Very useful if Steam is giving trouble or if you are getting a blank screen in Game Mode
-- **ujust fix-proton-hang** - Force terminates all processes related to wine and proton. Useful if you can't launch games after a game fails to close properly
-- **ujust bios** - Reboots straight into this device's BIOS/UEFI screen
-- **ujust restart-pipewire** - Crackling audio? Restarting Pipewire sometimes fixes that
-- **ujust enroll-secure-boot-key** - Enrolls the Nvidia driver & KMOD signing key for secure boot. You'll need this if you want to use Bazzite with Secure Boot enabled
-- **ujust clean-system** - Cleans up old unused podman images, volumes, flatpak packages and rpm-ostree content
+- `ujust update` - updates system, flatpaks, and containers all at once.
+- `ujust configure-grub` - Configures GRUB boot menu visibility.
+- `ujust fix-reset-steam` - Reset the Steam folder back to a fresh state without removing games, music, saves, etc. Very useful if Steam is giving trouble or if you are getting a blank screen in Game Mode.
+- `ujust fix-proton-hang` - Force terminates all processes related to wine and proton. Useful if you can't launch games after a game fails to close properly
+- `ujust bios` - Reboots straight into this device's BIOS/UEFI screen.
+- `ujust restart-pipewire` - Crackling audio? Restarting Pipewire sometimes fixes that.
+- `ujust enroll-secure-boot-key` - Enrolls the Nvidia driver & KMOD signing key for secure boot. You'll need this if you want to use Bazzite with Secure Boot enabled.
+- `ujust clean-system` - Cleans up old unused podman images, volumes, flatpak packages and rpm-ostree content.
 
 ### Configuration/Enabling Scripts
 
-- **ujust configure-waydroid** - a configuration helper for Waydroid. More information in [Waydroid Setup Guide](../Installing_and_Managing_Software/Waydroid_Setup_Guide.md)
-- **ujust setup-virtualization** - setup and configure virtualization and vfio
-- **ujust setup-sunshine** - toggle Sunshine Game Streaming host on or off
-- **ujust setup-luks-tpm-unlock** - enable auto LUKS unlock via TPM
-- **ujust setup-decky** - Install and configure Decky Loader
-- **ujust setup-boot-windows-steam** - Adds a script in Steam to boot Windows which is useful for dual-boot setups
-- **ujust enable-tailscale** - Enables support for Tailscale
-- **ujust enable-supergfxctl** - Enable Supergfxctl, a GPU switcher for hybrid laptops
-- **ujust bazzite-cli** - Bazzite CLI mod for Bluefin styled cli enhancements. More information in [Bazzite Command Line Tools](../Advanced/bazzite-cli.md)
+- `ujust configure-waydroid` - a configuration helper for Waydroid. More information in [Waydroid Setup Guide](../Installing_and_Managing_Software/Waydroid_Setup_Guide.md).
+- `ujust setup-virtualization` - setup and configure virtualization and vfio.
+- `ujust setup-sunshine` - toggle Sunshine Game Streaming host on or off.
+- `ujust setup-luks-tpm-unlock` - enable auto LUKS unlock via TPM.
+- `ujust setup-decky` - Install and configure Decky Loader.
+- `ujust setup-boot-windows-steam` - Adds a script in Steam to boot Windows which is useful for dual-boot setups.
+- `ujust enable-tailscale` - Enables support for Tailscale.
+- `ujust enable-supergfxctl` - Enable Supergfxctl, a GPU switcher for hybrid laptops.
+- `ujust bazzite-cli` - Bazzite CLI mod for Bluefin styled cli enhancements. More information in [Bazzite Command Line Tools](../Advanced/bazzite-cli.md).
 
 ### Troubleshooting Scripts
 
-- **ujust logs-last-boot** - Shows all messages from last boot
-- **ujust logs-this-boot** - Shows all messages from this boot
-- **ujust device-info** - Gathers useful device information to a pastebin. This is very useful for providing information when creating support tickets.
+- `ujust logs-last-boot` - Shows all messages from last boot.
+- `ujust logs-this-boot` - Shows all messages from this boot.
+- `ujust device-info` - Gathers useful device information to a pastebin. This is very useful for providing information when creating support tickets.
 
 ## Project Website
 

--- a/utils/install-deps.sh
+++ b/utils/install-deps.sh
@@ -11,14 +11,14 @@ brew_installs=(
 )
 
 # Skip brew requirement when all the required programs are available otherwise.
-for pkg in $brew_installs ; do
+for pkg in "${brew_installs[@]}" ; do
     if ! command -v $pkg >/dev/null; then
         echod "Missing package: $pkg"
         needs_brew=1
     fi
 done
 
-if [[ -n "$needs_brew" ]]; then
+if [[ $needs_brew -eq 1 ]]; then
     if ! command -v brew >/dev/null; then
         echod "Some required packages are missing, and brew is not available for a userspace-only installation."
         echod "If you are on a non-atomic system, installing them via your system package manager works as well."


### PR DESCRIPTION
Possible breaking change that affects other languages:

- The `theme: language:` key is added to specify an alias of an existing template provided by mkdocs-material. The root mkdocs config now has `language: en` which is consistent with the default.
  - I need it so as to specify the `zh_CN` locale to use material's `zh.html` as its base template.
  - **If a locale overrides it but the next one doesn't, the next locale will fail to build.** This is an upstream issue with how it restores the state following a custom override, and is unlikely to be fixed considering the upstream's current state.
  - It is therefore recommended that all locales add this key, even if it doesn't require an alias.
 
# LLM/integrity statement
- The `theme: language:` fix is proposed by LLM, and then manually verified by myself.
- I adopted the LLM's general explanation of the issue and paraphrased it here.
- I referred to the existing zh_HK translations at various points for general consistency between Simplified and Traditional Chinese texts in the process, but did not significantly copy anything over. All translations here are carried out by hand.