### PR TITLE
docs: update Login Screen settings location for Plasma and GNOME

### DIFF
--- a/src/General/issues_and_resolutions.md
+++ b/src/General/issues_and_resolutions.md
@@ -324,11 +324,11 @@ You will need to manually add your user to the **`usershares`** group.
 
 === "KDE Plasma"
 
-    Open **System Settings → Colors and Themes → Login Screen**. On that screen, tick **"Automatically log in"**, select your user and for the session, select **"Plasma"** and don't forget to to click on the **"Apply"** button.
+    Open **System Settings → Security and Privacy → Login Screen**. On that screen, tick **"Automatically log in"**, select your user and for the session, select **"Plasma"** and don't forget to to click on the **"Apply"** button.
 
 === "GNOME"
 
-    Open the **Settings application → Users**. Click the **Unlock** button in the top right corner. Then switch on **Automatic Login**.
+    Open the **Settings application → System → Users**. Click the **Unlock** button in the top right corner. Then switch on **Automatic Login**.
 
 ---
 


### PR DESCRIPTION
<!---               
Thank you for contributing to the Universal Blue project!
Here are some tips for you:

## Thank you for contributing to the Universal Blue project!

Please [read the Contributor's Guide](https://universal-blue.org/contributing.html) before submitting a pull request.

In this project we follow [Semantic PRs][1] and [Conventional Commits][2] to describe features and fixes we made. It would be nice if you did too as we use this to generate changelogs with the right sections: 

    feat(deck): enable this deck specific feature
    fix(ally): fix screen rotation on the ally
    feat(gnome): Stuff that is GNOME specific

If you're unsure a generic `feat:` or `fix:` is fine! Did you already use this? Awesome, thanks again! Not sure what this all means? Here are some [more examples][3].

[1]: https://github.com/Ezard/semantic-prs
[2]: https://www.conventionalcommits.org/en/v1.0.0/#summary
[3]: https://www.conventionalcommits.org/en/v1.0.0/#examples
-->

I've updated the location for Automatic Login for both Plasma and GNOME, the Plasma part was in this issue:

https://github.com/ublue-os/docs.bazzite.gg/issues/502

but since I'm on GNOME I figured I would update that as well.
